### PR TITLE
Always return true when assigning coerced values

### DIFF
--- a/lib/lotus/validations/attribute_validator.rb
+++ b/lib/lotus/validations/attribute_validator.rb
@@ -67,6 +67,7 @@ module Lotus
         _validate(:type) do |coercer|
           @value = Lotus::Utils::Kernel.send(coercer.to_s, @value)
           @validator.attributes[@name] = @value
+          true
         end
       end
 

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -33,18 +33,19 @@ class TypeValidatorTest
   include Lotus::Validations
 
   attribute :untyped
-  attribute :array_attr,    type: Array
-  attribute :boolean_attr,  type: Boolean
-  attribute :date_attr,     type: Date
-  attribute :datetime_attr, type: DateTime
-  attribute :float_attr,    type: Float
-  attribute :hash_attr,     type: Hash
-  attribute :integer_attr,  type: Integer
-  attribute :pathname_attr, type: Pathname
-  attribute :set_attr,      type: Set
-  attribute :string_attr,   type: String
-  attribute :symbol_attr,   type: Symbol
-  attribute :time_attr,     type: Time
+  attribute :array_attr,         type: Array
+  attribute :boolean_true_attr,  type: Boolean
+  attribute :boolean_false_attr, type: Boolean
+  attribute :date_attr,          type: Date
+  attribute :datetime_attr,      type: DateTime
+  attribute :float_attr,         type: Float
+  attribute :hash_attr,          type: Hash
+  attribute :integer_attr,       type: Integer
+  attribute :pathname_attr,      type: Pathname
+  attribute :set_attr,           type: Set
+  attribute :string_attr,        type: String
+  attribute :symbol_attr,        type: Symbol
+  attribute :time_attr,          type: Time
 end
 
 class PresenceValidatorTest

--- a/test/type_test.rb
+++ b/test/type_test.rb
@@ -4,20 +4,21 @@ describe Lotus::Validations do
   describe '.type' do
     before do
       @validator = TypeValidatorTest.new({
-        unmapped:       'Hello',
-        untyped:        '23',
-        array_attr:     Set.new(['a', 'b']),
-        boolean_attr:   '1',
-        date_attr:      '2014-08-03',
-        datetime_attr:  '2014-08-03 18:05:18',
-        float_attr:     '3.14',
-        hash_attr:      [[:a, 1]],
-        integer_attr:   '23',
-        pathname_attr:  'test/test_helper.rb',
-        set_attr:       [1, 2],
-        string_attr:    23,
-        symbol_attr:    'symbol',
-        time_attr:      '1407082408'
+        unmapped:           'Hello',
+        untyped:            '23',
+        array_attr:         Set.new(['a', 'b']),
+        boolean_true_attr:  '1',
+        boolean_false_attr: '0',
+        date_attr:          '2014-08-03',
+        datetime_attr:      '2014-08-03 18:05:18',
+        float_attr:         '3.14',
+        hash_attr:          [[:a, 1]],
+        integer_attr:       '23',
+        pathname_attr:      'test/test_helper.rb',
+        set_attr:           [1, 2],
+        string_attr:        23,
+        symbol_attr:        'symbol',
+        time_attr:          '1407082408'
       })
 
       @validator.valid?
@@ -31,8 +32,13 @@ describe Lotus::Validations do
       @validator.array_attr.must_be_kind_of(Array)
     end
 
-    it 'coerces Boolean' do
-      @validator.boolean_attr.must_be_kind_of(TrueClass)
+    it 'coerces Boolean true' do
+      @validator.boolean_true_attr.must_be_kind_of(TrueClass)
+    end
+
+    it 'coerces Boolean false' do
+      @validator.boolean_false_attr.must_be_kind_of(FalseClass)
+      @validator.errors.must_be_empty
     end
 
     it 'coerces Date' do


### PR DESCRIPTION
Coercing `'0'` to a boolean caused a validation error, since the block returned false.
