### PR TITLE
Skip validation if value is empty

### DIFF
--- a/lib/lotus/validations/attribute_validator.rb
+++ b/lib/lotus/validations/attribute_validator.rb
@@ -71,7 +71,7 @@ module Lotus
       end
 
       def skip?
-        @value.nil?
+        @value.nil? || (@value.respond_to?(:empty?) && @value.empty?)
       end
 
       def _run_validations

--- a/test/presence_validation_test.rb
+++ b/test/presence_validation_test.rb
@@ -16,5 +16,13 @@ describe Lotus::Validations do
       errors = validator.errors.for(:age)
       errors.must_include Lotus::Validations::Error.new(:age, :presence, true, nil)
     end
+
+    it "isn't valid if required attribute is empty" do
+      validator = PresenceValidatorTest.new(name: '', age: '32')
+
+      validator.valid?.must_equal false
+      errors = validator.errors.for(:name)
+      errors.must_include Lotus::Validations::Error.new(:name, :presence, true, '')
+    end
   end
 end


### PR DESCRIPTION
This currently causes a size validation test to fail (as `Array.new`, `Hash.new`, and `Set.new` respond to `empty?` and `empty?` returns true). I didn't change that test because I wanted to hear opinions first.
