### PR TITLE
Type coercer accepts custom classes

### DIFF
--- a/lib/lotus/validations/attribute_validator.rb
+++ b/lib/lotus/validations/attribute_validator.rb
@@ -1,4 +1,4 @@
-require 'lotus/utils/kernel'
+require 'lotus/validations/coercions'
 
 class Range
   def size
@@ -65,7 +65,7 @@ module Lotus
 
       def coerce
         _validate(:type) do |coercer|
-          @value = Lotus::Utils::Kernel.send(coercer.to_s, @value)
+          @value = Lotus::Validations::Coercions.coerce(coercer, @value)
           @validator.attributes[@name] = @value
         end
       end

--- a/lib/lotus/validations/coercions.rb
+++ b/lib/lotus/validations/coercions.rb
@@ -1,0 +1,15 @@
+require 'lotus/utils/kernel'
+
+module Lotus
+  module Validations
+    module Coercions
+      def self.coerce(coercer, *values, &blk)
+        if ::Lotus::Utils::Kernel.respond_to?(coercer.to_s)
+          ::Lotus::Utils::Kernel.__send__(coercer.to_s, *values, &blk)
+        else
+          coercer.new(*values, &blk)
+        end
+      end
+    end
+  end
+end

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -1,3 +1,13 @@
+class FullName
+  def initialize(*tokens)
+    @tokens = tokens
+  end
+
+  def to_s
+    @tokens.join ' '
+  end
+end
+
 class InitializerTest
   include Lotus::Validations
 
@@ -45,6 +55,7 @@ class TypeValidatorTest
   attribute :string_attr,   type: String
   attribute :symbol_attr,   type: Symbol
   attribute :time_attr,     type: Time
+  attribute :name_attr,     type: FullName
 end
 
 class PresenceValidatorTest

--- a/test/type_test.rb
+++ b/test/type_test.rb
@@ -17,7 +17,8 @@ describe Lotus::Validations do
         set_attr:       [1, 2],
         string_attr:    23,
         symbol_attr:    'symbol',
-        time_attr:      '1407082408'
+        time_attr:      '1407082408',
+        name_attr:      ['Luca', 'Guidi']
       })
 
       @validator.valid?
@@ -69,6 +70,10 @@ describe Lotus::Validations do
 
     it 'coerces Time' do
       @validator.time_attr.must_be_kind_of(Time)
+    end
+
+    it 'coerces custom type' do
+      @validator.name_attr.must_be_kind_of(FullName)
     end
   end
 end

--- a/test/validations/coercions_test.rb
+++ b/test/validations/coercions_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+require 'lotus/validations/coercions'
+
+describe Lotus::Validations::Coercions do
+  describe 'Lotus::Utils::Kernel coercions' do
+    it 'coerces value' do
+      result = Lotus::Validations::Coercions.coerce(Boolean, 1)
+      result.must_equal true
+    end
+  end
+
+  describe 'custom coercions' do
+    it 'coerces custom class' do
+      result = Lotus::Validations::Coercions.coerce(FullName, 'Luca', 'Guidi')
+
+      result.must_be_kind_of(FullName)
+      result.to_s.must_equal 'Luca Guidi'
+    end
+  end
+end


### PR DESCRIPTION
Example:

``` ruby
class FullName
  def initialize(*names)
    @names = names
  end

  def to_s
    @names.join ' '
  end
end

class UserValidator
  include Lotus::Validations

  attribute :full_name, type: FullName
end

validator = UserValidator.new(full_name: ['Luca', 'Guidi'])
validator.valid? # trigger coercions

puts validator.full_name.class # => FullName
puts validator.full_name       # => "Luca Guidi"
```
