### PR TITLE
Support nested validation

### DIFF
--- a/lib/lotus/validations/attribute_validator.rb
+++ b/lib/lotus/validations/attribute_validator.rb
@@ -97,8 +97,12 @@ module Lotus
       end
 
       def _validate(validation)
-        if (validator = @options[validation]) && !(yield validator)
-          @validator.errors.add(@name, validation, @options.fetch(validation), @value)
+        if validator = @options[validation]
+          condition = yield validator
+          if condition && @value.respond_to?(:valid?)
+            condition = @value.valid?
+          end
+          @validator.errors.add(@name, validation, @options.fetch(validation), @value) unless condition
         end
       end
     end

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -135,3 +135,9 @@ end
 class SubclassValidatorTest < SuperclassValidatorTest
   attribute :age, type: Integer, inclusion: 18..99
 end
+
+class NestedValidationTest
+  include Lotus::Validations
+
+  attribute :user, type: PresenceValidatorTest
+end

--- a/test/validations/coercions_test.rb
+++ b/test/validations/coercions_test.rb
@@ -17,4 +17,23 @@ describe Lotus::Validations::Coercions do
       result.to_s.must_equal 'Luca Guidi'
     end
   end
+
+  describe 'nested params' do
+    it "is valid when chlid is valid" do
+      validator = NestedValidationTest.new(user: {name: 'L', age: '32'})
+
+      validator.valid?.must_equal true
+      validator.instance_variable_get(:@attributes)[:user].valid?.must_equal true
+      validator.errors.must_be_empty
+    end
+
+    it "isn't valid when chlid is unvalid" do
+      validator = NestedValidationTest.new(user: {name: 'L'})
+
+      validator.valid?.must_equal false
+      validator.instance_variable_get(:@attributes)[:user].valid?.must_equal false
+      errors = validator.errors.for(:user).first.actual.errors
+      errors.for(:age).must_include Lotus::Validations::Error.new(:age, :presence, true, nil)
+    end
+  end
 end


### PR DESCRIPTION
Hi.

In recent, custom `type` validation is added.
However, it is diffcult to tell that given param is unvalid for custom `type`.
If this PR is merge, we can write that like

```
class User
  include Lotus::Validations
  attribute :name, presence: true
  attribute :age
end

class FriendShip
  include Lotus::Validations
  attribute :user, type: User
  attribute :friend, type: User
end
```

Thank you.
