### PR TITLE
Removes TODO from gemspec

### DIFF
--- a/lotus-validations.gemspec
+++ b/lotus-validations.gemspec
@@ -4,19 +4,19 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'lotus/validations/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "lotus-validations"
+  spec.name          = 'lotus-validations'
   spec.version       = Lotus::Validations::VERSION
-  spec.authors       = ["Luca Guidi"]
-  spec.email         = ["me@lucaguidi.com"]
-  spec.summary       = %q{TODO: Write a short summary. Required.}
-  spec.description   = %q{TODO: Write a longer description. Optional.}
-  spec.homepage      = ""
-  spec.license       = "MIT"
+  spec.authors       = ['Luca Guidi']
+  spec.email         = ['me@lucaguidi.com']
+  spec.summary       = %q{Validations for Lotus}
+  spec.description   = %q{Validate attributes on a class and manage error messages accordingly}
+  spec.homepage      = 'http://lotusrb.org'
+  spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
   spec.add_dependency 'lotus-utils', '~> 0.2'
 


### PR DESCRIPTION
Gemspec is invalid with TODO or FIXME messages. Removing such messages allows the gem to build and be included in other libraries.
