### PR TITLE
Made Lotus::Validation::Errors#each and #map 4x faster

### DIFF
--- a/lib/lotus/validations/errors.rb
+++ b/lib/lotus/validations/errors.rb
@@ -55,9 +55,7 @@ module Lotus
       #
       # @since 0.1.0
       def each(&blk)
-        errors.each do |error|
-          blk.call(error)
-        end
+        errors.each(&blk)
       end
 
       # Iterate thru the errors, yields the given block and collect the
@@ -70,9 +68,7 @@ module Lotus
       #
       # @since 0.1.0
       def map(&blk)
-        errors.map do |error|
-          blk.call(error)
-        end
+        errors.map(&blk)
       end
 
       # Add an error to the set


### PR DESCRIPTION
```
Calculating -------------------------------------
            each blk       568 i/100ms
   each delegate blk      1978 i/100ms
-------------------------------------------------
            each blk     5746.3 (±2.5%) i/s -      28968 in   5.044358s
   each delegate blk    20033.4 (±2.6%) i/s -     100878 in   5.039105s
```

_"each blk"_ was the old algorithm, _"each delegate blk"_ is the new one.
Benchmark available at: https://gist.github.com/jodosha/df7270fbb4562027bbb8
