### PR TITLE
Accepts strings as keys, only for declared attributes

### DIFF
--- a/lib/lotus/validations/attributes.rb
+++ b/lib/lotus/validations/attributes.rb
@@ -6,7 +6,10 @@ module Lotus
 
         @attributes = Utils::Hash.new.tap do |result|
           definitions.each do |name, validations|
-            result[name] = Attribute.new(self, name, attributes[name], validations)
+            value = attributes[name]
+            value = attributes[name.to_s] if value.nil?
+
+            result[name] = Attribute.new(self, name, value, validations)
           end
         end
       end

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -193,3 +193,10 @@ class DecoratedValidations
 
   attribute :password, confirmation: true
 end
+
+class Signin
+  include Lotus::Validations
+
+  attribute :email,    presence: true
+  attribute :password, presence: true
+end

--- a/test/initialize_test.rb
+++ b/test/initialize_test.rb
@@ -36,5 +36,12 @@ describe Lotus::Validations do
 
       @validator.wont_respond_to(:another)
     end
+
+    it "accepts strings as keys, only for the defined attributes" do
+      validator = Signin.new('email' => 'user@example.org', 'password' => '123', 'unknown' => 'blah')
+      validator.must_be :valid?
+
+      validator.to_h.must_equal({ email: 'user@example.org', password: '123' })
+    end
   end
 end


### PR DESCRIPTION
Example:

``` ruby
require 'lotus/validations'

class Signin
  include Lotus::Validations

  attribute :email,    presence: true
  attribute :password, presence: true
end

signin = Signin.new('email' => 'user@example.org', 'password' => '123', 'unknown' => 'blah')
signin.valid? # => true
signin.to_h   # => { :email => 'user@example.org', :password => '123' }
```

Closes #20 
