### PR TITLE
Non whitelist attributes in absence of attributes definitions

### DIFF
--- a/lib/lotus/validations/attribute_set.rb
+++ b/lib/lotus/validations/attribute_set.rb
@@ -15,10 +15,17 @@ class AttributeSet
     @attributes.each(&blk)
   end
 
-  def to_ary
-    @attributes.keys
+  def iterate(attributes, &blk)
+    if @attributes.any?
+      @attributes.each(&blk)
+    else
+      attributes.each do |name, _|
+        blk.call(name, {})
+      end
+    end
   end
 
+  private
   # Checks at the loading time if the user defined validations are recognized
   #
   # @param name [Symbol] the attribute name

--- a/lib/lotus/validations/attributes.rb
+++ b/lib/lotus/validations/attributes.rb
@@ -5,7 +5,7 @@ module Lotus
         attributes  = attributes.to_h
 
         @attributes = Utils::Hash.new.tap do |result|
-          definitions.each do |name, validations|
+          definitions.iterate(attributes) do |name, validations|
             value = attributes[name]
             value = attributes[name.to_s] if value.nil?
 
@@ -15,7 +15,7 @@ module Lotus
       end
 
       def get(name)
-        @attributes[name].value
+        (attr = @attributes[name]) and attr.value
       end
 
       def dup

--- a/test/attribute_test.rb
+++ b/test/attribute_test.rb
@@ -3,11 +3,11 @@ require 'test_helper'
 describe Lotus::Validations do
   describe '.attribute' do
     it 'coerces attribute names to symbols' do
-      AttributeTest.__send__(:attributes).to_ary.must_include(:attr)
+      assert AttributeTest.defined_attribute?(:attr)
     end
 
     it 'ensures attribute uniqueness' do
-      UniquenessAttributeTest.__send__(:attributes).to_ary.must_include(:attr)
+      assert UniquenessAttributeTest.defined_attribute?(:attr)
     end
 
     it 'collects multiple errors for a single attribute' do

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -26,12 +26,22 @@ end
 
 class AttributeTest
   include Lotus::Validations
+  extend  Lotus::Validations::AttributesIntrospection
 
   attribute 'attr'
 end
 
+class UndefinedAttributesValidator
+  include Lotus::Validations
+
+  def [](key)
+    @attributes.get(key)
+  end
+end
+
 class UniquenessAttributeTest
   include Lotus::Validations
+  extend  Lotus::Validations::AttributesIntrospection
 
   attribute :attr
   attribute :attr

--- a/test/initialize_test.rb
+++ b/test/initialize_test.rb
@@ -49,5 +49,15 @@ describe Lotus::Validations do
 
       validator.to_h.must_equal({ email: 'user@example.org', password: '123', password_confirmation: '123' })
     end
+
+    it "doesn't whitelist attributes in case of missing definitions" do
+      validator = UndefinedAttributesValidator.new('a' => 1, :b => 2)
+
+      validator.must_be :valid?
+      validator.to_h.must_equal({ 'a' => 1, :b => 2 })
+
+      validator['a'].must_equal 1
+      validator[:a].must_be_nil
+    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,4 +19,11 @@ end
 require 'minitest/autorun'
 $:.unshift 'lib'
 require 'lotus/validations'
+
+module Lotus::Validations::AttributesIntrospection
+  def defined_attribute?(name)
+    attributes.instance_variable_get(:@attributes).keys.include?(name)
+  end
+end
+
 require 'fixtures'


### PR DESCRIPTION
When a validator doesn't define any attribute, don't whitelist at the initialization time.
This is for a Lotus::Controller compatibility.
