### PR TITLE
High level rules

### DIFF
--- a/test/form/rules_test.rb
+++ b/test/form/rules_test.rb
@@ -1,0 +1,87 @@
+require 'test_helper'
+require 'uri'
+
+describe Hanami::Validations::Form do
+  describe 'rules' do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations::Form
+
+        validations do
+          required(:type).filled(:int?, included_in?: [1, 2, 3])
+
+          optional(:location).maybe(:str?)
+          optional(:remote).maybe(:bool?)
+
+          required(:title).filled(:str?)
+          required(:description).filled(:str?)
+          required(:company).filled(:str?)
+
+          optional(:website).filled(:str?, format?: URI.regexp(%w(http https)))
+
+          rule(location_presence: [:location, :remote]) do |location, remote|
+            (remote.none? | remote.false?).then(location.filled?) &
+              remote.true?.then(location.none?)
+          end
+        end
+      end
+    end
+
+    let(:input) do
+      Hash[
+        'type'        => '1',
+        'title'       => 'Developer',
+        'description' => 'You know, to write code.',
+        'company'     => 'Acme Inc.'
+      ]
+    end
+
+    it 'is valid when location is filled and remote is missing' do
+      data   = input.merge('location' => 'Rome')
+      result = @validator.new(data).validate
+
+      result.must_be :success?
+      result.messages.must_be_empty
+    end
+
+    it 'is valid when location is filled and remote is false' do
+      data   = input.merge('location' => 'Rome', 'remote' => '0')
+      result = @validator.new(data).validate
+
+      result.must_be :success?
+      result.messages.must_be_empty
+    end
+
+    it 'is valid when location is missing and remote is true' do
+      data   = input.merge('remote' => '1')
+      result = @validator.new(data).validate
+
+      result.must_be :success?
+      result.messages.must_be_empty
+    end
+
+    it 'is invalid when both location and remote are missing' do
+      data   = input
+      result = @validator.new(data).validate
+
+      result.wont_be :success?
+      result.messages.wont_be_empty
+    end
+
+    it 'is invalid when location is missing and remote is false' do
+      data   = input.merge('remote' => '0')
+      result = @validator.new(data).validate
+
+      result.wont_be :success?
+      result.messages.fetch(:location).must_equal ['must be filled']
+    end
+
+    it 'is invalid when location is filled and remote is true' do
+      data   = input.merge('location' => 'Rome', 'remote' => '1')
+      result = @validator.new(data).validate
+
+      result.wont_be :success?
+      result.messages.fetch(:location).must_equal ['cannot be defined']
+    end
+  end
+end

--- a/test/rules_test.rb
+++ b/test/rules_test.rb
@@ -1,0 +1,71 @@
+require 'test_helper'
+require 'securerandom'
+
+describe Hanami::Validations do
+  describe 'rules' do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations
+
+        validations do
+          configure do
+            def self.messages
+              super.merge(
+                en: {
+                  errors: {
+                    quick_code_presence: 'you must set quick code for connection type "a"',
+                    uuid_presence:       'you must set uuid for connection type "b"'
+                  }
+                }
+              )
+            end
+          end
+
+          required(:connection_type).filled(:str?, included_in?: %w(a b c))
+          optional(:quick_code).maybe(:str?)
+          optional(:uuid).maybe(:str?)
+
+          rule(quick_code_presence: [:connection_type, :quick_code]) do |connection_type, quick_code|
+            connection_type.eql?('a') > quick_code.filled?
+          end
+
+          rule(uuid_presence: [:connection_type, :uuid]) do |connection_type, uuid|
+            connection_type.eql?('b') > uuid.filled?
+          end
+        end
+      end
+    end
+
+    describe 'quick code' do
+      it 'returns successful validation result for valid data' do
+        result = @validator.new(connection_type: 'a', quick_code: '123').validate
+
+        result.must_be :success?
+        result.errors.must_be_empty
+      end
+
+      it 'returns failing validation result when quick code is missing' do
+        result = @validator.new(connection_type: 'a').validate
+
+        result.wont_be :success?
+        result.messages.fetch(:quick_code_presence).must_equal ['you must set quick code for connection type "a"']
+      end
+    end
+
+    describe 'uuid' do
+      it 'returns successful validation result for valid data' do
+        result = @validator.new(connection_type: 'b', uuid: SecureRandom.uuid).validate
+
+        result.must_be :success?
+        result.errors.must_be_empty
+      end
+
+      it 'returns failing validation result when uuid is missing' do
+        result = @validator.new(connection_type: 'b').validate
+
+        result.wont_be :success?
+        result.messages.fetch(:uuid_presence).must_equal ['you must set uuid for connection type "b"']
+      end
+    end
+  end
+end


### PR DESCRIPTION
## High Level Rules

Predicates and macros are tools to code validations that concern a single key like `first_name` or `email`.
If the outcome of a validation depends on two or more attributes we can use _rules_.

Here's a practical example: a job board.
We want to validate the form of the job creation with some mandatory fields: `type` (full time, part-time, contract), `title` (eg. Developer), `description`, `company` (just the name) and a `website` (which is optional).
An user must specify the location: on-site or remote. If it's on site, they must specify the `location`, otherwise they have to tick the checkbox for `remote`.

Here's the code:

```ruby
class CreateJob
  include Hanami::Validations::Form

  validations do
    required(:type).filled(:int?, included_in?: [1, 2, 3])

    optional(:location).maybe(:str?)
    optional(:remote).maybe(:bool?)

    required(:title).filled(:str?)
    required(:description).filled(:str?)
    required(:company).filled(:str?)

    optional(:website).filled(:str?, format?: URI.regexp(%w(http https)))

    rule(location_presence: [:location, :remote]) do |location, remote|
      (remote.none? | remote.false?).then(location.filled?) &
        remote.true?.then(location.none?)
    end
  end
end
```

We specify a rule with `rule` method, which takes an arbitrary name and an array of preconditions.
Only if `:location` and `:remote` are valid according to their validations described above, the `rule` block is evaluated.

The block yields the same exact keys that we put in the precondintions.
So for `[:location, :remote]` it will yield the corresponding values, bound to the `location` and `remote` variables.

We can use these variables to define the rule. We covered a few cases:

  * If `remote` is missing or false, then `location` must be filled
  * If `remote` is true, then `location` must be omitted

---

Closes #80 

/cc @hanami/core-team @hanami/contributors 