### PR TITLE
Concat I18n load-paths, otherwise they are being overridden

### DIFF
--- a/test/support/fixtures.rb
+++ b/test/support/fixtures.rb
@@ -1,7 +1,7 @@
 require 'i18n'
 require 'dry/validation/messages/i18n'
 
-I18n.load_path = Dir['test/fixtures/i18n/*.yml']
+I18n.load_path.concat(Dir['test/fixtures/i18n/*.yml'])
 I18n.backend.load_translations
 
 module SharedPredicates


### PR DESCRIPTION
I honestly don't know how this was passing on travis, but I18n is full of surprises so...:)