### PR TITLE
Change alias of datetime to date_time

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ It takes the input and tries to coerce it. If it fails, the execution stops. If 
   * `BigDecimal` (aliased as `decimal?`)
   * `Boolean` (aliased as `bool?`)
   * `Date` (aliased as `date?`)
-  * `DateTime` (aliased as `datetime?`)
+  * `DateTime` (aliased as `date_time?`)
   * `Float` (aliased as `float?`)
   * `Hash` (aliased as `hash?`)
   * `Integer` (aliased as `int?`)


### PR DESCRIPTION
I did this because DateTime is aliased as 'date_time' in
dry-validation, not 'datetime' like the README says. Reference Link:
https://github.com/dry-rb/dry-validation/blob/4dbe0a5b58b1fce1ee730bb5a10bb1c6aba3cc64/lib/dry/validation/input_processor_compiler/sanitizer.rb#L13