### PR TITLE
Depend on dry-validation ~> 0.11

### DIFF
--- a/hanami-validations.gemspec
+++ b/hanami-validations.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3.0'
 
   spec.add_dependency 'hanami-utils',   '~> 1.2'
-  spec.add_dependency 'dry-validation', '~> 0.12'
+  spec.add_dependency 'dry-validation', '~> 0.11', '< 0.12'
 
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'rake',    '~> 10'

--- a/lib/hanami/validations/form.rb
+++ b/lib/hanami/validations/form.rb
@@ -60,7 +60,7 @@ module Hanami
         # @since 0.6.0
         # @api private
         def _schema_type
-          :Params
+          :Form
         end
       end
     end


### PR DESCRIPTION
We can't depend on `dry-validation` `~> 0.12` because it requires `dry-types` `~> 0.13`, which isn't compatible with the current `dry-types` version (`~> 0.11`) that we use for `hanami-model` `1.2`.

This because `hanami-model` depends on ROM 3.

Having `dry-validation` set on `~> 0.12` will make impossible to run `bundle update` on a Hanami project.

---

Ref https://github.com/hanami/validations/pull/143