### PR TITLE
Depend on dry-validation ~> 0.11

### DIFF
--- a/hanami-validations.gemspec
+++ b/hanami-validations.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.3.0"
 
   spec.add_dependency "hanami-utils",   "~> 2.0.alpha"
-  spec.add_dependency "dry-validation", "~> 0.12"
+  spec.add_dependency "dry-validation", "~> 0.11", "< 0.12"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake",    "~> 10"


### PR DESCRIPTION
This commit fixes resolving deps in hanami build for `unstable` branch.
Original commit in master https://github.com/hanami/validations/commit/f2bf92c9094dab6df80cd0d955c029fb895167c2

Ref https://github.com/hanami/hanami/pull/940