### PR TITLE
Revert "Rewriting"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,6 @@
 # Hanami::Validations
 Validations mixin for Ruby objects
 
-## v2.0.0.alpha1 (unreleased)
-### Added
-- [Luca Guidi] The result object respond to `#failing?`
-- [Luca Guidi] The result object can serialize data with `#to_hash`
-
-### Changed
-- [Luca Guidi] Introduced `Hanami::Validator` as superclass to inherit from
-- [Luca Guidi] Including `Hanami::Validations` will not inject validations
-- [Luca Guidi] Removed `Hanami::Validations::Form`, in favor of `validations(:form)`
-- [Luca Guidi] `#initialize` doesn't accept any argument
-- [Luca Guidi] Validators are frozen
-- [Luca Guidi] Input data must be passed as argument to `#call`, instead of `#initialize`
-- [Luca Guidi] The returning value of a validation (result) can be `Hanami::Success` or `Hanami::Validations::Failure`
-- [Luca Guidi] The result object doesn't respond to `#success?` but to `#successful?`
-
 ## v1.3.0.beta1 (unreleased)
 
 ## v1.2.2 - 2018-06-05

--- a/Gemfile
+++ b/Gemfile
@@ -8,10 +8,8 @@ unless ENV["TRAVIS"]
   gem "yard",   require: false
 end
 
-gem "dry-validation", git: "https://github.com/dry-rb/dry-validation.git"
-gem "dry-types",      git: "https://github.com/dry-rb/dry-types.git"
-gem "hanami-utils", "~> 2.0.alpha", require: false, git: "https://github.com/hanami/utils.git", branch: "feature/result"
+gem "hanami-utils", "~> 2.0.alpha", require: false, git: "https://github.com/hanami/utils.git", branch: "unstable"
 
 gem "hanami-devtools", require: false, git: "https://github.com/hanami/devtools.git"
-gem "i18n", "~> 1.0",  require: false
+gem "i18n", "~> 0.9",  require: false
 gem "coveralls",       require: false

--- a/lib/hanami/validations.rb
+++ b/lib/hanami/validations.rb
@@ -7,9 +7,6 @@ require "hanami/validations/predicates"
 require "hanami/validations/inline_predicate"
 require "set"
 
-require "hanami/result"
-require "hanami/utils/string"
-
 Dry::Validation::Messages::Namespaced.configure do |config|
   # rubocop:disable Lint/NestedPercentLiteral
   #
@@ -23,49 +20,6 @@ end
 
 # @since 0.1.0
 module Hanami
-  # Validator
-  class Validator
-    def self.inherited(base)
-      super
-
-      base.class_eval do
-        @schema = nil
-        extend ClassMethods
-      end
-    end
-
-    # Class level interface
-    module ClassMethods
-      def validations(type = :schema, &blk)
-        t = case type
-            when :schema then :Schema
-            when :form   then :Params
-            when :json   then :JSON
-            else
-              raise ArgumentError.new("unsupported schema type: #{type.inspect}")
-            end
-
-        @schema = Dry::Validation.send(t, &blk)
-      end
-
-      attr_reader :schema
-    end
-
-    def initialize
-      freeze
-    end
-
-    def call(input)
-      result = self.class.schema.call(input.to_hash)
-
-      if result.success?
-        Hanami::Success.new(result.output)
-      else
-        Hanami::Validations::Failure.new(result.messages, result.output)
-      end
-    end
-  end
-
   # Hanami::Validations is a set of lightweight validations for Ruby objects.
   #
   # @since 0.1.0
@@ -73,35 +27,354 @@ module Hanami
   # @example
   #   require 'hanami/validations'
   #
-  #   class Signup < Hanami::Validator
+  #   class Signup
+  #     include Hanami::Validations
+  #
   #     validations do
   #       # ...
   #     end
   #   end
   module Validations
-    # Failure
-    class Failure < Hanami::Failure
-      # Hash
-      attr_reader :messages
+    # @since 0.6.0
+    # @api private
+    DEFAULT_MESSAGES_ENGINE = :yaml
 
-      def initialize(messages, **data)
-        @messages = messages.freeze
-        @data     = data.freeze
+    # Override Ruby's hook for modules.
+    #
+    # @param base [Class] the target action
+    #
+    # @since 0.1.0
+    # @api private
+    #
+    # @see http://www.ruby-doc.org/core/Module.html#method-i-included
+    def self.included(base) # rubocop:disable Metrics/MethodLength
+      base.class_eval do
+        extend ClassMethods
+
+        include Utils::ClassAttribute
+        class_attribute :schema
+        class_attribute :_messages
+        class_attribute :_messages_path
+        class_attribute :_namespace
+        class_attribute :_predicates_module
+
+        class_attribute :_predicates
+        self._predicates = Set.new
+      end
+    end
+
+    # Validations DSL
+    #
+    # @since 0.1.0
+    module ClassMethods
+      # Define validation rules from the given block.
+      #
+      # @param blk [Proc] validation rules
+      #
+      # @since 0.6.0
+      #
+      # @see http://hanamirb.org/guides/validations/overview/
+      #
+      # @example Basic Example
+      #   require 'hanami/validations'
+      #
+      #   class Signup
+      #     include Hanami::Validations
+      #
+      #     validations do
+      #       required(:name).filled
+      #     end
+      #   end
+      #
+      #   result = Signup.new(name: "Luca").validate
+      #
+      #   result.success? # => true
+      #   result.messages # => []
+      #   result.output   # => {:name=>""}
+      #
+      #   result = Signup.new(name: "").validate
+      #
+      #   result.success? # => false
+      #   result.messages # => {:name=>["must be filled"]}
+      #   result.output   # => {:name=>""}
+      def validations(&blk) # rubocop:disable Metrics/AbcSize
+        schema_predicates = _predicates_module || __predicates
+
+        base   = _build(predicates: schema_predicates, &_base_rules)
+        schema = _build(predicates: schema_predicates, rules: base.rules, &blk)
+        schema.configure(&_schema_config)
+        schema.configure(&_schema_predicates)
+        schema.extend(__messages) unless _predicates.empty?
+
+        self.schema = schema.new
       end
 
-      def full_messages(error_set = messages)
-        error_set.each_with_object([]) do |(key, messages), result|
-          k = Utils::String.titleize(key)
+      # Define an inline predicate
+      #
+      # @param name [Symbol] inline predicate name
+      # @param message [String] optional error message
+      # @param blk [Proc] predicate implementation
+      #
+      # @return nil
+      #
+      # @since 0.6.0
+      #
+      # @example Without Custom Message
+      #   require 'hanami/validations'
+      #
+      #   class Signup
+      #     include Hanami::Validations
+      #
+      #     predicate :foo? do |actual|
+      #       actual == 'foo'
+      #     end
+      #
+      #     validations do
+      #       required(:name).filled(:foo?)
+      #     end
+      #   end
+      #
+      #   result = Signup.new(name: nil).call
+      #   result.messages # => { :name => ['is invalid'] }
+      #
+      # @example With Custom Message
+      #   require 'hanami/validations'
+      #
+      #   class Signup
+      #     include Hanami::Validations
+      #
+      #     predicate :foo?, message: 'must be foo' do |actual|
+      #       actual == 'foo'
+      #     end
+      #
+      #     validations do
+      #       required(:name).filled(:foo?)
+      #     end
+      #   end
+      #
+      #   result = Signup.new(name: nil).call
+      #   result.messages # => { :name => ['must be foo'] }
+      def predicate(name, message: "is invalid", &blk)
+        _predicates << InlinePredicate.new(name, message, &blk)
+      end
 
-          msgs = if messages.is_a?(::Hash)
-                   full_messages(messages)
-                 else
-                   messages.map { |message| "#{k} #{message}" }
-                 end
+      # Assign a set of shared predicates wrapped in a module
+      #
+      # @param mod [Module] a module with shared predicates
+      #
+      # @since 0.6.0
+      #
+      # @see Hanami::Validations::Predicates
+      #
+      # @example
+      #   require 'hanami/validations'
+      #
+      #   module MySharedPredicates
+      #     include Hanami::Validations::Predicates
+      #
+      #     predicate :foo? fo |actual|
+      #       actual == 'foo'
+      #     end
+      #   end
+      #
+      #   class MyValidator
+      #     include Hanami::Validations
+      #     predicates MySharedPredicates
+      #
+      #     validations do
+      #       required(:name).filled(:foo?)
+      #     end
+      #   end
+      def predicates(mod)
+        self._predicates_module = mod
+      end
 
-          result.concat(msgs)
+      # Define the type of engine for error messages.
+      #
+      # Accepted values are `:yaml` (default), `:i18n`.
+      #
+      # @param type [Symbol] the preferred engine
+      #
+      # @since 0.6.0
+      #
+      # @example
+      #   require 'hanami/validations'
+      #
+      #   class Signup
+      #     include Hanami::Validations
+      #
+      #     messages :i18n
+      #   end
+      def messages(type)
+        self._messages = type
+      end
+
+      # Define the path where to find translation file
+      #
+      # @param path [String] path to translation file
+      #
+      # @since 0.6.0
+      #
+      # @example
+      #   require 'hanami/validations'
+      #
+      #   class Signup
+      #     include Hanami::Validations
+      #
+      #     messages_path 'config/messages.yml'
+      #   end
+      def messages_path(path)
+        self._messages_path = path
+      end
+
+      # Namespace for error messages.
+      #
+      # @param name [String] namespace
+      #
+      # @since 0.6.0
+      #
+      # @example
+      #   require 'hanami/validations'
+      #
+      #   module MyApp
+      #     module Validators
+      #       class Signup
+      #         include Hanami::Validations
+      #
+      #         namespace 'signup'
+      #       end
+      #     end
+      #   end
+      #
+      #   # Instead of looking for error messages under the `my_app.validator.signup`
+      #   # namespace, it will look just for `signup`.
+      #   #
+      #   # This helps to simplify YAML files where are stored error messages
+      def namespace(name = nil)
+        if name.nil?
+          Namespace.new(_namespace, self)
+        else
+          self._namespace = name.to_s
         end
       end
+
+      private
+
+      # @since 0.6.0
+      # @api private
+      def _build(options = {}, &blk)
+        options = { build: false }.merge(options)
+        Dry::Validation.__send__(_schema_type, options, &blk)
+      end
+
+      # @since 0.6.0
+      # @api private
+      def _schema_type
+        :Schema
+      end
+
+      # @since 0.6.0
+      # @api private
+      def _base_rules
+        lambda do
+        end
+      end
+
+      # @since 0.6.0
+      # @api private
+      def _schema_config
+        lambda do |config|
+          config.messages      = _messages      unless _messages.nil?
+          config.messages_file = _messages_path unless _messages_path.nil?
+          config.namespace     = namespace
+        end
+      end
+
+      # @since 0.6.0
+      # @api private
+      def _schema_predicates
+        return if _predicates_module.nil? && _predicates.empty?
+
+        lambda do |config|
+          config.messages      = _predicates_module&.messages || DEFAULT_MESSAGES_ENGINE
+          config.messages_file = _predicates_module.messages_path unless _predicates_module.nil?
+        end
+      end
+
+      # @since 0.6.0
+      # @api private
+      def __predicates
+        mod = Module.new { include Hanami::Validations::Predicates }
+
+        _predicates.each do |p|
+          mod.module_eval do
+            predicate(p.name, &p.to_proc)
+          end
+        end
+
+        mod
+      end
+
+      # @since 0.6.0
+      # @api private
+      def __messages # rubocop:disable Metrics/MethodLength
+        result = _predicates.each_with_object({}) do |p, ret|
+          ret[p.name] = p.message
+        end
+
+        # @api private
+        Module.new do
+          @@__messages = result # rubocop:disable Style/ClassVars
+
+          # @api private
+          def self.extended(base)
+            base.instance_eval do
+              def __messages
+                Hash[en: { errors: @@__messages }]
+              end
+            end
+          end
+
+          # @api private
+          def messages
+            engine = super
+
+            if engine.respond_to?(:merge)
+              engine
+            else
+              engine.messages
+            end.merge(__messages)
+          end
+        end
+      end
+    end
+
+    # Initialize a new instance of a validator
+    #
+    # @param input [#to_h] a set of input data
+    #
+    # @since 0.6.0
+    def initialize(input = {})
+      @input = input.to_h
+    end
+
+    # Validates the object.
+    #
+    # @return [Dry::Validations::Result]
+    #
+    # @since 0.2.4
+    def validate
+      self.class.schema.call(@input)
+    end
+
+    # Returns a Hash with the defined attributes as symbolized keys, and their
+    # relative values.
+    #
+    # @return [Hash]
+    #
+    # @since 0.1.0
+    def to_h
+      validate.output
     end
   end
 end

--- a/lib/hanami/validations/form.rb
+++ b/lib/hanami/validations/form.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "hanami/validations"
+
+module Hanami
+  module Validations
+    # Validations mixin for forms/HTTP params.
+    #
+    # This must be used when the input comes from a browser or an HTTP endpoint.
+    # It knows how to deal with common data types, and common edge cases like blank strings.
+    #
+    # @since 0.6.0
+    #
+    # @example
+    #   require 'hanami/validations/form'
+    #
+    #   class Signup
+    #     include Hanami::Validations::Form
+    #
+    #     validations do
+    #       required(:name).filled(:str?)
+    #       optional(:location).filled(:str?)
+    #     end
+    #   end
+    #
+    #   result = Signup.new('location' => 'Rome').validate
+    #   result.success? # => false
+    #
+    #   result = Signup.new('name' => 'Luca').validate
+    #   result.success? # => true
+    #
+    #   # it works with symbol keys too
+    #   result = Signup.new(location: 'Rome').validate
+    #   result.success? # => false
+    #
+    #   result = Signup.new(name: 'Luca').validate
+    #   result.success? # => true
+    #
+    #   result = Signup.new(name: 'Luca', location: 'Rome').validate
+    #   result.success? # => true
+    module Form
+      # Override Ruby's hook for modules.
+      #
+      # @param base [Class] the target action
+      #
+      # @since 0.6.0
+      # @api private
+      #
+      # @see http://www.ruby-doc.org/core/Module.html#method-i-included
+      def self.included(base)
+        base.class_eval do
+          include Validations
+          extend  ClassMethods
+        end
+      end
+
+      # @since 0.6.0
+      # @api private
+      module ClassMethods
+        private
+
+        # @since 0.6.0
+        # @api private
+        def _schema_type
+          :Params
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,6 +32,7 @@ end
 $LOAD_PATH.unshift "lib"
 require "hanami/utils"
 require "hanami/validations"
+require "hanami/validations/form"
 
 Hanami::Utils.require!("spec/support")
 Hanami::Utils.require!("spec/shared")

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -16,12 +16,11 @@ module SharedPredicates
   end
 end
 
-class SignupValidator < Hanami::Validator
-  validations do
-    configure do
-      config.messages_file = "spec/support/fixtures/messages.yml"
-    end
+class SignupValidator
+  include Hanami::Validations
+  messages_path "spec/support/fixtures/messages.yml"
 
+  validations do
     required(:age).filled(:int?, gt?: 18)
   end
 end
@@ -30,12 +29,11 @@ module Web
   module Controllers
     module Signup
       class Create
-        class Params < Hanami::Validator
-          validations(:form) do
-            configure do
-              config.messages_file = "spec/support/fixtures/messages.yml"
-            end
+        class Params
+          include Hanami::Validations::Form
+          messages_path "spec/support/fixtures/messages.yml"
 
+          validations do
             required(:age).filled(:int?, gt?: 18)
           end
         end
@@ -44,22 +42,21 @@ module Web
   end
 end
 
-class DomainValidator < Hanami::Validator
-  validations do
-    configure do
-      config.messages = :i18n
-    end
+class DomainValidator
+  include Hanami::Validations
+  messages :i18n
 
+  validations do
     required(:name).filled(:str?, max_size?: 253)
   end
 end
 
-class ChangedTermsOfServicesValidator < Hanami::Validator
-  validations(:form) do
-    configure do
-      predicates(SharedPredicates)
-    end
+class ChangedTermsOfServicesValidator
+  include Hanami::Validations::Form
 
+  predicates SharedPredicates
+
+  validations do
     required(:terms).filled(:bool?, :accepted?)
   end
 end

--- a/spec/unit/hanami/validations/base_validations_spec.rb
+++ b/spec/unit/hanami/validations/base_validations_spec.rb
@@ -1,67 +1,79 @@
 # frozen_string_literal: true
 
-RSpec.describe Hanami::Validator do
+RSpec.describe Hanami::Validations do
   describe "base validations" do
-    subject do
-      Class.new(Hanami::Validator) do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations
+
+        def self._base_rules
+          lambda do
+            optional(:_csrf_token).filled(:str?)
+          end
+        end
+
         validations do
           required(:number).filled(:int?, eql?: 23)
         end
-      end.new
+      end
     end
 
     it "returns successful validation result with bare minimum valid data" do
-      result = subject.call(number: 23)
+      result = @validator.new(number: 23).validate
 
-      expect(result).to be_successful
-      expect(result.to_h).to eq(number: 23)
+      expect(result).to be_success
+      expect(result.errors).to be_empty
+
+      expect(result.output).to eq(number: 23)
     end
 
     it "returns successful validation result with full valid data" do
-      result = subject.call(number: 23, _csrf_token: "abc")
+      result = @validator.new(number: 23, _csrf_token: "abc").validate
 
-      expect(result).to be_successful
-      expect(result.to_h).to eq(number: 23, _csrf_token: "abc")
+      expect(result).to be_success
+      expect(result.messages).to be_empty
+
+      expect(result.output).to eq(number: 23, _csrf_token: "abc")
     end
 
     it "returns failing validation result with bare minimum invalid data" do
-      result = subject.call(number: 11)
+      result = @validator.new(number: 11).validate
 
-      expect(result).to be_failing
+      expect(result).not_to be_success
       expect(result.messages.fetch(:number)).to eq          ["must be equal to 23"]
       expect(result.messages.fetch(:_csrf_token, [])).to eq []
 
-      expect(result.to_h).to eq(number: 11)
+      expect(result.output).to eq(number: 11)
     end
 
-    xit "returns failing validation result with full invalid data" do
-      result = subject.call(number: 8, _csrf_token: "")
+    it "returns failing validation result with full invalid data" do
+      result = @validator.new(number: 8, _csrf_token: "").validate
 
-      expect(result).to be_failing
+      expect(result).not_to be_success
       expect(result.messages.fetch(:number)).to eq      ["must be equal to 23"]
       expect(result.messages.fetch(:_csrf_token)).to eq ["must be filled"]
 
-      expect(result.to_h).to eq(number: 8, _csrf_token: "")
+      expect(result.output).to eq(number: 8, _csrf_token: "")
     end
 
-    xit "returns failing validation result with base invalid data" do
-      result = subject.call(number: 23, _csrf_token: "")
+    it "returns failing validation result with base invalid data" do
+      result = @validator.new(number: 23, _csrf_token: "").validate
 
-      expect(result).to be_failing
+      expect(result).not_to be_success
       expect(result.messages.fetch(:number, [])).to eq  []
       expect(result.messages.fetch(:_csrf_token)).to eq ["must be filled"]
 
-      expect(result.to_h).to eq(number: 23, _csrf_token: "")
+      expect(result.output).to eq(number: 23, _csrf_token: "")
     end
 
     it "returns failing validation result for invalid data" do
-      result = subject.call({})
+      result = @validator.new({}).validate
 
-      expect(result).to be_failing
+      expect(result).not_to be_success
       expect(result.messages.fetch(:number)).to eq          ["is missing", "must be equal to 23"]
       expect(result.messages.fetch(:_csrf_token, [])).to eq []
 
-      expect(result.to_h).to eq({})
+      expect(result.output).to eq({})
     end
   end
 end

--- a/spec/unit/hanami/validations/combinable_spec.rb
+++ b/spec/unit/hanami/validations/combinable_spec.rb
@@ -1,63 +1,66 @@
 # frozen_string_literal: true
 
-RSpec.describe Hanami::Validator do
+RSpec.describe Hanami::Validations do
   describe "combinable validations" do
-    let(:address) do
-      Class.new(Hanami::Validator) do
+    before do
+      address = Class.new do
+        include Hanami::Validations
+
         validations do
           required(:city) { filled? }
         end
       end
-    end
 
-    let(:customer) do
-      Class.new(Hanami::Validator) do
+      customer = Class.new do
+        include Hanami::Validations
+
         validations do
           required(:name) { filled? }
           # FIXME: ask dry team to support any object that responds to #schema.
           required(:address).schema(address.schema)
         end
       end
-    end
 
-    subject do
-      Class.new(Hanami::Validator) do
+      @order = Class.new do
+        include Hanami::Validations
+
         validations do
           required(:number) { filled? }
           required(:customer).schema(customer.schema)
         end
-      end.new
+      end
     end
 
-    xit "returns successful validation result for valid data" do
-      result = subject.call(number: 23, customer: { name: "Luca", address: { city: "Rome" } })
+    it "returns successful validation result for valid data" do
+      result = @order.new(number: 23, customer: { name: "Luca", address: { city: "Rome" } }).validate
       expect(result).to be_success
+      expect(result.errors).to be_empty
     end
 
-    xit "returns failing validation result for invalid data" do
-      result = subject.call({})
+    it "returns failing validation result for invalid data" do
+      result = @order.new({}).validate
 
-      expect(result).to be_failing
+      expect(result).not_to be_success
       expect(result.messages.fetch(:number)).to eq   ["is missing"]
       expect(result.messages.fetch(:customer)).to eq ["is missing"]
     end
 
     # Bug
     # See https://github.com/hanami/validations/issues/58
-    xit "safely serialize to nested Hash" do
-      data   = { name: "John Smith", address: { line_one: "10 High Street" } }
-      result = subject.call(data)
+    it "safely serialize to nested Hash" do
+      data      = { name: "John Smith", address: { line_one: "10 High Street" } }
+      validator = @order.new(data)
 
-      expect(result.to_h).to eq(data)
+      expect(validator.to_h).to eq(data)
     end
 
     # Bug
     # See https://github.com/hanami/validations/issues/58#issuecomment-99144243
-    xit "safely serialize to Hash" do
-      data   = { name: "John Smith", tags: [1, 2] }
-      result = subject.call(data)
+    it "safely serialize to Hash" do
+      data      = { name: "John Smith", tags: [1, 2] }
+      validator = @order.new(data)
 
-      expect(result.to_h).to eq(data)
+      expect(validator.to_h).to eq(data)
     end
   end
 end

--- a/spec/unit/hanami/validations/form/base_validations_spec.rb
+++ b/spec/unit/hanami/validations/form/base_validations_spec.rb
@@ -1,82 +1,88 @@
 # frozen_string_literal: true
 
-RSpec.describe Hanami::Validator do
-  describe "form" do
-    describe "base validations" do
-      subject do
-        Class.new(Hanami::Validator) do
-          # def self._base_rules
-          #   lambda do
-          #     optional(:_csrf_token).filled(:str?)
-          #   end
-          # end
+RSpec.describe Hanami::Validations::Form do
+  describe "base validations" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations::Form
 
-          validations(:form) do
-            required(:number).filled(:int?, eql?: 23)
+        def self._base_rules
+          lambda do
+            optional(:_csrf_token).filled(:str?)
           end
-        end.new
+        end
+
+        validations do
+          required(:number).filled(:int?, eql?: 23)
+        end
       end
+    end
 
-      it "returns successful validation result with bare minimum valid data" do
-        result = subject.call("number" => "23")
+    it "returns successful validation result with bare minimum valid data" do
+      result = @validator.new("number" => "23").validate
 
-        expect(result).to be_successful
-        expect(result.to_h).to eq(number: 23)
-      end
+      expect(result).to be_success
+      expect(result.errors).to be_empty
 
-      xit "returns successful validation result with full valid data" do
-        result = subject.call("number" => "23", "_csrf_token" => "abc")
+      expect(result.output).to eq(number: 23)
+    end
 
-        expect(result).to be_successful
-        expect(result.to_h).to eq(number: 23, _csrf_token: "abc")
-      end
+    it "returns successful validation result with full valid data" do
+      result = @validator.new("number" => "23", "_csrf_token" => "abc").validate
 
-      it "returns failing validation result with bare minimum invalid data" do
-        result = subject.call("number" => "11")
+      expect(result).to be_success
+      expect(result.errors).to be_empty
 
-        expect(result).to be_failing
-        expect(result.messages.fetch(:number)).to          eq(["must be equal to 23"])
-        expect(result.messages.fetch(:_csrf_token, [])).to eq([])
+      expect(result.output).to eq(number: 23, _csrf_token: "abc")
+    end
 
-        expect(result.to_h).to eq(number: 11)
-      end
+    it "returns failing validation result with bare minimum invalid data" do
+      result = @validator.new("number" => "11").validate
 
-      xit "returns failing validation result with full invalid data" do
-        result = subject.call("number" => "8", "_csrf_token" => "")
+      expect(result).not_to be_success
+      expect(result.messages.fetch(:number)).to eq          ["must be equal to 23"]
+      expect(result.messages.fetch(:_csrf_token, [])).to eq []
 
-        expect(result).to be_failing
-        expect(result.messages.fetch(:number)).to      eq(["must be equal to 23"])
-        expect(result.messages.fetch(:_csrf_token)).to eq(["must be filled"])
+      expect(result.output).to eq(number: 11)
+    end
 
-        expect(result.to_h).to eq(number: 8, _csrf_token: "")
-      end
+    it "returns failing validation result with full invalid data" do
+      result = @validator.new("number" => "8", "_csrf_token" => "").validate
 
-      xit "returns failing validation result with base invalid data" do
-        result = subject.call("number" => "23", "_csrf_token" => "")
+      expect(result).not_to be_success
+      expect(result.messages.fetch(:number)).to eq      ["must be equal to 23"]
+      expect(result.messages.fetch(:_csrf_token)).to eq ["must be filled"]
 
-        expect(result).to be_failing
-        expect(result.messages.fetch(:number, [])).to  eq([])
-        expect(result.messages.fetch(:_csrf_token)).to eq(["must be filled"])
+      expect(result.output).to eq(number: 8, _csrf_token: "")
+    end
 
-        expect(result.to_h).to eq(number: 23, _csrf_token: "")
-      end
+    it "returns failing validation result with base invalid data" do
+      result = @validator.new("number" => "23", "_csrf_token" => "").validate
 
-      it "returns failing validation result for invalid data" do
-        result = subject.call({})
+      expect(result).not_to be_success
+      expect(result.messages.fetch(:number, [])).to eq  []
+      expect(result.messages.fetch(:_csrf_token)).to eq ["must be filled"]
 
-        expect(result).to be_failing
-        expect(result.messages.fetch(:number)).to          eq(["is missing", "must be equal to 23"])
-        expect(result.messages.fetch(:_csrf_token, [])).to eq([])
+      expect(result.output).to eq(number: 23, _csrf_token: "")
+    end
 
-        expect(result.to_h).to eq({})
-      end
+    it "returns failing validation result for invalid data" do
+      result = @validator.new({}).validate
 
-      xit "whitelists known keys" do
-        result = subject.call("number" => "23", "_csrf_token" => "abc", "foo" => "bar")
+      expect(result).not_to be_success
+      expect(result.messages.fetch(:number)).to eq          ["is missing", "must be equal to 23"]
+      expect(result.messages.fetch(:_csrf_token, [])).to eq []
 
-        expect(result).to be_successful
-        expect(result.to_h).to eq(number: 23, _csrf_token: "abc")
-      end
+      expect(result.output).to eq({})
+    end
+
+    it "whitelists known keys" do
+      result = @validator.new("number" => "23", "_csrf_token" => "abc", "foo" => "bar").validate
+
+      expect(result).to be_success
+      expect(result.messages).to be_empty
+
+      expect(result.output).to eq(number: 23, _csrf_token: "abc")
     end
   end
 end

--- a/spec/unit/hanami/validations/form/initialize_spec.rb
+++ b/spec/unit/hanami/validations/form/initialize_spec.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-RSpec.describe Hanami::Validations do
+RSpec.describe Hanami::Validations::Form do
   describe "#initialize" do
     before do
       @validator = Class.new do
-        include Hanami::Validations
+        include Hanami::Validations::Form
 
         validations do
           required(:attr) { type?(Integer) }
@@ -12,7 +12,7 @@ RSpec.describe Hanami::Validations do
       end
 
       @nested = Class.new do
-        include Hanami::Validations
+        include Hanami::Validations::Form
 
         validations do
           required(:foo) { filled? }
@@ -52,11 +52,6 @@ RSpec.describe Hanami::Validations do
       expect(validator.to_h.fetch(:attr)).to eq 23
     end
 
-    it "accepts zero arguments" do
-      validator = @validator.new
-      expect(validator.to_h).to eq({})
-    end
-
     it "doesn't modify the original attributes" do
       data       = { attr: "23" }
       validator  = @validator.new(data)
@@ -65,14 +60,14 @@ RSpec.describe Hanami::Validations do
       expect(data[:attr]).to eq("23")
     end
 
-    it "accepts symbols as keys, without coercing and whitelisting" do
+    it "accepts strings as keys, only for the defined attributes" do
       validator = @nested.new(
-        foo:     "ok",
-        num:     23,
-        unknown: "no",
-        bar: {
-          baz: "yo",
-          wat: "oh"
+        "foo"     => "ok",
+        "num"     => "23",
+        "unknown" => "no",
+        "bar" => {
+          "baz" => "yo",
+          "wat" => "oh"
         }
       )
 
@@ -80,12 +75,10 @@ RSpec.describe Hanami::Validations do
 
       expect(result).to be_success
       expect(result.output).to eq(
-        foo:     "ok",
-        num:     23,
-        unknown: "no",
+        foo: "ok",
+        num: 23,
         bar: {
-          baz: "yo",
-          wat: "oh"
+          baz: "yo"
         }
       )
 

--- a/spec/unit/hanami/validations/form/nested_spec.rb
+++ b/spec/unit/hanami/validations/form/nested_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+RSpec.describe Hanami::Validations::Form do
+  describe "nested validations" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations::Form
+
+        validations do
+          required(:number) { filled? }
+
+          required(:customer).schema do
+            required(:name) { filled? }
+
+            required(:address).schema do
+              required(:city) { filled? }
+            end
+          end
+        end
+      end
+    end
+
+    it "returns successful validation result for valid data" do
+      result = @validator.new("number" => "23", "customer" => { "name" => "Luca", "address" => { "city" => "Rome" } }).validate
+
+      expect(result).to be_success
+      expect(result.errors).to be_empty
+    end
+
+    it "returns failing validation result for invalid data" do
+      result = @validator.new({}).validate
+
+      expect(result).not_to be_success
+      expect(result.messages.fetch(:number)).to eq ["is missing"]
+      expect(result.messages.fetch(:customer)).to eq ["is missing"]
+    end
+
+    # Bug
+    # See https://github.com/hanami/validations/issues/58
+    it "safely serialize to nested Hash" do
+      data      = { "customer" => { "name" => "John Smith", "address" => { "city" => "London" } } }
+      validator = @validator.new(data)
+
+      expect(validator.to_h).to eq(customer: { name: "John Smith", address: { city: "London" } })
+    end
+  end
+end

--- a/spec/unit/hanami/validations/form/rules_spec.rb
+++ b/spec/unit/hanami/validations/form/rules_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "uri"
+
+RSpec.describe Hanami::Validations::Form do
+  describe "rules" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations::Form
+
+        validations do
+          required(:type).filled(:int?, included_in?: [1, 2, 3])
+
+          optional(:location).maybe(:str?)
+          optional(:remote).maybe(:bool?)
+
+          required(:title).filled(:str?)
+          required(:description).filled(:str?)
+          required(:company).filled(:str?)
+
+          optional(:website).filled(:str?, format?: URI::REGEXP)
+
+          rule(location: %i[location remote]) do |location, remote|
+            (remote.none? | remote.false?).then(location.filled?) &
+              remote.true?.then(location.none?)
+          end
+        end
+      end
+    end
+
+    let(:input) do
+      Hash[
+        "type"        => "1",
+        "title"       => "Developer",
+        "description" => "You know, to write code.",
+        "company"     => "Acme Inc."
+      ]
+    end
+
+    it "is valid when location is filled and remote is missing" do
+      data   = input.merge("location" => "Rome")
+      result = @validator.new(data).validate
+
+      expect(result).to be_success
+      expect(result.errors).to be_empty
+    end
+
+    it "is valid when location is filled and remote is false" do
+      data   = input.merge("location" => "Rome", "remote" => "0")
+      result = @validator.new(data).validate
+
+      expect(result).to be_success
+      expect(result.errors).to be_empty
+    end
+
+    it "is valid when location is missing and remote is true" do
+      data   = input.merge("remote" => "1")
+      result = @validator.new(data).validate
+
+      expect(result).to be_success
+      expect(result.errors).to be_empty
+    end
+
+    it "is invalid when both location and remote are missing" do
+      data   = input
+      result = @validator.new(data).validate
+
+      expect(result).not_to be_success
+      expect(result.errors).not_to be_empty
+    end
+
+    it "is invalid when location is missing and remote is false" do
+      data   = input.merge("remote" => "0")
+      result = @validator.new(data).validate
+
+      expect(result).not_to be_success
+      expect(result.messages.fetch(:location)).to eq ["must be filled"]
+    end
+
+    it "is invalid when location is filled and remote is true" do
+      data   = input.merge("location" => "Rome", "remote" => "1")
+      result = @validator.new(data).validate
+
+      expect(result).not_to be_success
+      expect(result.messages.fetch(:location)).to eq ["cannot be defined"]
+    end
+  end
+end

--- a/spec/unit/hanami/validations/messages_spec.rb
+++ b/spec/unit/hanami/validations/messages_spec.rb
@@ -2,68 +2,75 @@
 
 RSpec.describe "Messages" do
   describe "with anonymous class" do
-    subject do
-      Class.new(Hanami::Validator) do
-        validations do
-          configure do
-            config.messages_file = "spec/support/fixtures/messages.yml"
-            config.namespace     = :foo
-          end
+    before do
+      @validator = Class.new do
+        include Hanami::Validations
+        messages_path "spec/support/fixtures/messages.yml"
+        namespace :foo
 
+        validations do
           required(:age).filled(:int?, gt?: 18)
         end
-      end.new
+      end
     end
 
     it "returns configured message" do
-      result = subject.call(age: 11)
+      result = @validator.new(age: 11).validate
 
-      expect(result).to be_failing
-      expect(result.messages.fetch(:age)).to eq(["must be an adult"])
+      expect(result).not_to be_success
+      expect(result.messages.fetch(:age)).to eq ["must be an adult"]
     end
   end
 
   describe "with concrete class" do
-    subject { SignupValidator.new }
+    before do
+      @validator = SignupValidator
+    end
 
-    xit "returns configured message" do
-      result = subject.call(age: 11)
+    it "returns configured message" do
+      result = @validator.new(age: 11).validate
 
-      expect(result).to be_failing
-      expect(result.messages.fetch(:age)).to eq(["must be an adult"])
+      expect(result).not_to be_success
+      expect(result.messages.fetch(:age)).to eq ["must be an adult"]
     end
   end
 
   describe "with concrete namespaced class" do
-    subject { Web::Controllers::Signup::Create::Params.new }
+    before do
+      @validator = Web::Controllers::Signup::Create::Params
+    end
 
-    xit "returns configured message" do
-      result = subject.call(age: 11)
+    it "returns configured message" do
+      result = @validator.new(age: 11).validate
 
-      expect(result).to be_failing
-      expect(result.messages.fetch(:age)).to eq(["must be an adult"])
+      expect(result).not_to be_success
+      expect(result.messages.fetch(:age)).to eq ["must be an adult"]
     end
   end
 
   describe "with i18n support" do
-    subject { DomainValidator.new }
+    before do
+      @validator = DomainValidator
+    end
 
-    xit "returns configured message" do
-      result = subject.call(name: "a" * 256)
+    it "returns configured message" do
+      result = @validator.new(name: "a" * 256).validate
 
-      expect(result).to be_failing
-      expect(result.messages.fetch(:name)).to eq(["is too long"])
+      expect(result).not_to be_success
+      expect(result.messages.fetch(:name)).to eq ["is too long"]
     end
   end
 
   describe "with i18n support and shared predicates" do
-    subject { ChangedTermsOfServicesValidator.new }
+    before do
+      @validator = ChangedTermsOfServicesValidator
+    end
 
-    xit "returns configured message" do
-      result = subject.call(terms: "false")
+    it "returns configured message" do
+      result = @validator.new(terms: "false").validate
 
-      expect(result).to be_failing
-      expect(result.messages.fetch(:terms)).to eq(["must be accepted"])
+      expect(result).not_to be_success
+      expect(result.messages.fetch(:terms)).to eq ["must be accepted"]
     end
   end
 end

--- a/spec/unit/hanami/validations/nested_spec.rb
+++ b/spec/unit/hanami/validations/nested_spec.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
-RSpec.describe Hanami::Validator do
+RSpec.describe Hanami::Validations do
   describe "nested validations" do
-    subject do
-      Class.new(Hanami::Validator) do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations
+
         validations do
           required(:number) { filled? }
           required(:code) { filled? & eql?("foo") }
@@ -17,27 +19,28 @@ RSpec.describe Hanami::Validator do
             end
           end
         end
-      end.new
+      end
     end
 
     it "returns successful validation result for valid data" do
-      result = subject.call(number: 23, code: "foo", customer: { name: "Luca", code: "bar", address: { city: "Rome" } })
+      result = @validator.new(number: 23, code: "foo", customer: { name: "Luca", code: "bar", address: { city: "Rome" } }).validate
 
-      expect(result).to be_successful
+      expect(result).to be_success
+      expect(result.errors).to be_empty
     end
 
     it "returns failing validation result for invalid data" do
-      result = subject.call({})
+      result = @validator.new({}).validate
 
-      expect(result).not_to be_successful
+      expect(result).not_to be_success
       expect(result.messages.fetch(:number)).to eq ["is missing"]
       expect(result.messages.fetch(:customer)).to eq ["is missing"]
     end
 
     it "returns different failing validations for keys with the same name" do
-      result = subject.call(code: "x", customer: { code: "y" })
+      result = @validator.new(code: "x", customer: { code: "y" }).validate
 
-      expect(result).not_to be_successful
+      expect(result).not_to be_success
       expect(result.messages.fetch(:code)).to eq ["must be equal to foo"]
       expect(result.messages.fetch(:customer).fetch(:code)).to eq ["must be equal to bar"]
     end
@@ -46,7 +49,7 @@ RSpec.describe Hanami::Validator do
     # See https://github.com/hanami/validations/issues/58
     it "safely serialize to nested Hash" do
       data      = { name: "John Smith", address: { line_one: "10 High Street" } }
-      validator = subject.call(data)
+      validator = @validator.new(data)
 
       expect(validator.to_h).to eq(data)
     end
@@ -55,7 +58,7 @@ RSpec.describe Hanami::Validator do
     # See https://github.com/hanami/validations/issues/58#issuecomment-99144243
     it "safely serialize to Hash" do
       data      = { name: "John Smith", tags: [1, 2] }
-      validator = subject.call(data)
+      validator = @validator.new(data)
 
       expect(validator.to_h).to eq(data)
     end

--- a/spec/unit/hanami/validations/predicates/form/array_spec.rb
+++ b/spec/unit/hanami/validations/predicates/form/array_spec.rb
@@ -1,0 +1,247 @@
+# frozen_string_literal: true
+
+RSpec.describe "Predicates: Array" do
+  include_context "validator result"
+
+  describe "with required" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations::Form
+
+        validations do
+          required(:foo) { array? { each { int? } } }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { "foo" => ["3"] } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is not successful" do
+        expect_not_successful result, ["is missing"]
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { "foo" => nil } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be an array"]
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { "foo" => "" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with invalid type" do
+      let(:input) { { "foo" => { "a" => "1" } } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be an array"]
+      end
+    end
+
+    describe "with invalid input (integer)" do
+      let(:input) { { "foo" => "4" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be an array"]
+      end
+    end
+
+    describe "with invalid input (array with non-integers)" do
+      let(:input) { { "foo" => %w[foo bar] } }
+
+      it "is not successful" do
+        expect_not_successful result, 0 => ["must be an integer"], 1 => ["must be an integer"]
+      end
+    end
+
+    describe "with invalid input (mixed array)" do
+      let(:input) { { "foo" => %w[1 bar] } }
+
+      it "is not successful" do
+        expect_not_successful result, 1 => ["must be an integer"]
+      end
+    end
+  end
+
+  describe "with optional" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations::Form
+
+        validations do
+          optional(:foo) { included_in?(%w[1 3 5]) }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { "foo" => "3" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { "foo" => nil } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be one of: 1, 3, 5"]
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { "foo" => "" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be one of: 1, 3, 5"]
+      end
+    end
+
+    describe "with invalid type" do
+      let(:input) { { "foo" => { "a" => "1" } } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be one of: 1, 3, 5"]
+      end
+    end
+
+    describe "with invalid input" do
+      let(:input) { { "foo" => "4" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be one of: 1, 3, 5"]
+      end
+    end
+  end
+
+  describe "as macro" do
+    describe "with required" do
+      before do
+        @validator = Class.new do
+          include Hanami::Validations::Form
+
+          validations do
+            required(:foo).each(:int?)
+          end
+        end
+      end
+
+      describe "with missing input" do
+        let(:input) { {} }
+
+        it "is not successful" do
+          expect_not_successful result, ["is missing"]
+        end
+      end
+
+      describe "with nil input" do
+        let(:input) { { "foo" => nil } }
+
+        it "is not successful" do
+          expect_not_successful result, ["must be an array"]
+        end
+      end
+
+      describe "with blank input" do
+        let(:input) { { "foo" => "" } }
+
+        it "is successful" do
+          expect_successful result
+        end
+      end
+
+      describe "with valid input" do
+        let(:input) { { "foo" => ["3"] } }
+
+        it "is successful" do
+          expect_successful result
+        end
+      end
+
+      describe "with invalid input" do
+        let(:input) { { "foo" => ["bar"] } }
+
+        it "is not successful" do
+          expect_not_successful result, 0 => ["must be an integer"]
+        end
+      end
+    end
+
+    describe "with optional" do
+      before do
+        @validator = Class.new do
+          include Hanami::Validations::Form
+
+          validations do
+            optional(:foo).each(:int?)
+          end
+        end
+      end
+
+      describe "with missing input" do
+        let(:input) { {} }
+
+        it "is not successful" do
+          expect_successful result
+        end
+      end
+
+      describe "with nil input" do
+        let(:input) { { "foo" => nil } }
+
+        it "is not successful" do
+          expect_not_successful result, ["must be an array"]
+        end
+      end
+
+      describe "with blank input" do
+        let(:input) { { "foo" => "" } }
+
+        it "is successful" do
+          expect_successful result
+        end
+      end
+
+      describe "with valid input" do
+        let(:input) { { "foo" => ["3"] } }
+
+        it "is successful" do
+          expect_successful result
+        end
+      end
+
+      describe "with invalid input" do
+        let(:input) { { "foo" => ["bar"] } }
+
+        it "is not successful" do
+          expect_not_successful result, 0 => ["must be an integer"]
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/validations/predicates/form/custom_spec.rb
+++ b/spec/unit/hanami/validations/predicates/form/custom_spec.rb
@@ -1,0 +1,217 @@
+# frozen_string_literal: true
+
+RSpec.describe "Predicates: custom" do
+  include_context "validator result"
+
+  describe "with custom predicate" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations::Form
+
+        def self.name
+          "Validator"
+        end
+
+        validations do
+          configure do
+            config.messages_file = "spec/support/fixtures/messages.yml"
+
+            def email?(current)
+              current.match(/\@/)
+            end
+          end
+
+          required(:foo) { email? }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { foo: "test@hanamirb.org" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with invalid input" do
+      let(:input) { { foo: "test" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be an email"]
+      end
+    end
+  end
+
+  describe "with custom predicates as module" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations::Form
+
+        def self.name
+          "Validator"
+        end
+
+        predicates(
+          Module.new do
+            include Hanami::Validations::Predicates
+            self.messages_path = "spec/support/fixtures/messages.yml"
+
+            predicate(:email?) do |current|
+              current.match(/@/)
+            end
+          end
+        )
+
+        validations do
+          required(:foo) { email? }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { foo: "test@hanamirb.org" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with invalid input" do
+      let(:input) { { foo: "test" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be an email"]
+      end
+    end
+  end
+
+  describe "with custom predicate within predicates block" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations::Form
+
+        def self.name
+          "Validator"
+        end
+
+        predicate :url?, message: "must be an URL" do |current|
+          current.start_with?("http")
+        end
+
+        validations do
+          required(:foo) { url? }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { foo: "http://hanamirb.org" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with invalid input" do
+      let(:input) { { foo: "test" } }
+
+      it "is successful" do
+        expect_not_successful result, ["must be an URL"]
+      end
+    end
+  end
+
+  describe "with custom predicate with predicate macro" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations::Form
+
+        def self.name
+          "Validator"
+        end
+
+        predicate :api_date?, message: "must be in iso8601 format" do |value|
+          begin
+            Date.iso8601(value)
+            true
+          rescue ArgumentError
+            false
+          end
+        end
+
+        validations do
+          required(:id).filled
+          required(:confirmed_at).filled(:api_date?)
+        end
+      end
+    end
+
+    describe "with valid data" do
+      let(:input) { { id: 1, confirmed_at: Date.today.iso8601 } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with invalid data" do
+      let(:input) { { id: 1, confirmed_at: "foo" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be in iso8601 format"], :confirmed_at
+      end
+    end
+  end
+
+  describe "without custom predicate" do
+    it "raises error if try to use an unknown predicate" do
+      expect do
+        Class.new do
+          include Hanami::Validations::Form
+
+          def self.name
+            "Validator"
+          end
+
+          validations do
+            required(:foo) { email? }
+          end
+        end
+      end.to raise_error(ArgumentError, "+email?+ is not a valid predicate name")
+    end
+  end
+
+  describe "with nested validations" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations::Form
+
+        def self.name
+          "Validator"
+        end
+
+        validations do
+          required(:details).schema do
+            configure do
+              config.messages_file = "spec/support/fixtures/messages.yml"
+
+              def odd?(current)
+                current.odd?
+              end
+            end
+
+            required(:foo) { odd? }
+          end
+        end
+      end
+    end
+
+    it "allows groups to define their own custom predicates" do
+      result = @validator.new(details: { foo: 2 }).validate
+
+      expect(result).not_to be_success
+      expect(result.messages[:details][:foo]).to eq ["must be odd"]
+    end
+  end
+end

--- a/spec/unit/hanami/validations/predicates/form/empty_spec.rb
+++ b/spec/unit/hanami/validations/predicates/form/empty_spec.rb
@@ -1,0 +1,291 @@
+# frozen_string_literal: true
+
+RSpec.describe "Predicates: Empty" do
+  include_context "validator result"
+
+  describe "with required" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations::Form
+
+        validations do
+          required(:foo) { empty? }
+        end
+      end
+    end
+
+    describe "with valid input (array)" do
+      let(:input) { { "foo" => [] } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with valid input (hash)" do
+      let(:input) { { "foo" => {} } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is not successful" do
+        expect_not_successful result, ["is missing", "must be empty"]
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { "foo" => nil } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { "foo" => "" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with invalid input" do
+      let(:input) { { "foo" => ["23"] } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be empty"]
+      end
+    end
+  end
+
+  describe "with optional" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations::Form
+
+        validations do
+          optional(:foo) { empty? }
+        end
+      end
+    end
+
+    describe "with valid input (array)" do
+      let(:input) { { "foo" => [] } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with valid input (hash)" do
+      let(:input) { { "foo" => {} } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { "foo" => nil } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { "foo" => "" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with invalid input" do
+      let(:input) { { "foo" => ["23"] } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be empty"]
+      end
+    end
+  end
+
+  describe "as macro" do
+    describe "with required" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              required(:foo).value(:empty?)
+            end
+          end
+        end
+
+        describe "with valid input (array)" do
+          let(:input) { { "foo" => [] } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with valid input (hash)" do
+          let(:input) { { "foo" => {} } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be empty"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { "foo" => ["23"] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be empty"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        # it doesn't make sense to ask for a filled key and at the same time assert it's empty
+        #
+        # Example:
+        #
+        #   validations do
+        #     required(:foo).filled(:empty?)
+        #   end
+      end
+
+      describe "with maybe" do
+        # it doesn't make sense to ask for a maybe key and at the same time assert it's empty
+        #
+        # Example:
+        #
+        #   validations do
+        #     required(:foo).maybe(:empty?)
+        #   end
+      end
+    end
+
+    describe "with optional" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              optional(:foo).value(:empty?)
+            end
+          end
+        end
+
+        describe "with valid input (array)" do
+          let(:input) { { "foo" => [] } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with valid input (hash)" do
+          let(:input) { { "foo" => {} } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { "foo" => ["23"] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be empty"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        # it doesn't make sense to ask for a filled key and at the same time assert it's empty
+        #
+        # Example:
+        #
+        #   validations do
+        #     optional(:foo).filled(:empty?)
+        #   end
+      end
+
+      describe "with maybe" do
+        # it doesn't make sense to ask for a filled key and at the same time assert it's empty
+        #
+        # Example:
+        #
+        #   validations do
+        #     optional(:foo).maybe(:empty?)
+        #   end
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/validations/predicates/form/eql_spec.rb
+++ b/spec/unit/hanami/validations/predicates/form/eql_spec.rb
@@ -1,0 +1,363 @@
+# frozen_string_literal: true
+
+RSpec.describe "Predicates: Eql" do
+  include_context "validator result"
+
+  describe "with required" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations::Form
+
+        validations do
+          required(:foo) { eql?("23") }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { "foo" => "23" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is not successful" do
+        expect_not_successful result, ["is missing", "must be equal to 23"]
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { "foo" => nil } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be equal to 23"]
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { "foo" => "" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be equal to 23"]
+      end
+    end
+  end
+
+  describe "with optional" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations::Form
+
+        validations do
+          optional(:foo) { eql?("23") }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { "foo" => "23" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { "foo" => nil } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be equal to 23"]
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { "foo" => "" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be equal to 23"]
+      end
+    end
+  end
+
+  describe "as macro" do
+    describe "with required" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              required(:foo).value(eql?: "23")
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "23" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be equal to 23"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be equal to 23"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be equal to 23"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              required(:foo).filled(eql?: "23")
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "23" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be equal to 23"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be equal to 23"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be equal to 23"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              required(:foo).maybe(eql?: "23")
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "23" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be equal to 23"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+      end
+    end
+
+    describe "with optional" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              optional(:foo).value(eql?: "23")
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "23" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be equal to 23"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be equal to 23"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              optional(:foo).filled(eql?: "23")
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "23" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be equal to 23"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be equal to 23"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              optional(:foo).maybe(eql?: "23")
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "23" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/validations/predicates/form/excluded_from_spec.rb
+++ b/spec/unit/hanami/validations/predicates/form/excluded_from_spec.rb
@@ -1,0 +1,491 @@
+# frozen_string_literal: true
+
+RSpec.describe "Predicates: Excluded From" do
+  include_context "validator result"
+
+  describe "with required" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations::Form
+
+        validations do
+          required(:foo) { excluded_from?(%w[1 3 5]) }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { "foo" => "2" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is not successful" do
+        expect_not_successful result, ["is missing", "must not be one of: 1, 3, 5"]
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { "foo" => nil } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { "foo" => "" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with invalid type" do
+      let(:input) { { "foo" => { "a" => "1" } } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with invalid input" do
+      let(:input) { { "foo" => "5" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must not be one of: 1, 3, 5"]
+      end
+    end
+  end
+
+  describe "with optional" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations::Form
+
+        validations do
+          optional(:foo) { excluded_from?(%w[1 3 5]) }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { "foo" => "2" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { "foo" => nil } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { "foo" => "" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with invalid type" do
+      let(:input) { { "foo" => { "a" => "1" } } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with invalid input" do
+      let(:input) { { "foo" => "5" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must not be one of: 1, 3, 5"]
+      end
+    end
+  end
+
+  describe "as macro" do
+    describe "with required" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              required(:foo).value(excluded_from?: %w[1 3 5])
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "2" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must not be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { "foo" => { "a" => "1" } } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { "foo" => "5" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must not be one of: 1, 3, 5"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              required(:foo).filled(excluded_from?: %w[1 3 5])
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "2" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must not be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must not be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must not be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { "foo" => { "a" => "1" } } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { "foo" => "5" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must not be one of: 1, 3, 5"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              required(:foo).maybe(excluded_from?: %w[1 3 5])
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "2" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must not be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { "foo" => { "a" => "1" } } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { "foo" => "5" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must not be one of: 1, 3, 5"]
+          end
+        end
+      end
+    end
+
+    describe "with optional" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              optional(:foo).value(excluded_from?: %w[1 3 5])
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "2" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { "foo" => { "a" => "1" } } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { "foo" => "5" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must not be one of: 1, 3, 5"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              optional(:foo).filled(excluded_from?: %w[1 3 5])
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "2" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must not be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must not be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { "foo" => { "a" => "1" } } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { "foo" => "5" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must not be one of: 1, 3, 5"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              optional(:foo).maybe(excluded_from?: %w[1 3 5])
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "2" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { "foo" => { "a" => "1" } } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { "foo" => "5" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must not be one of: 1, 3, 5"]
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/validations/predicates/form/filled_spec.rb
+++ b/spec/unit/hanami/validations/predicates/form/filled_spec.rb
@@ -1,0 +1,491 @@
+# frozen_string_literal: true
+
+RSpec.describe "Predicates: Filled" do
+  include_context "validator result"
+
+  describe "with key" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations::Form
+
+        validations do
+          required(:foo) { filled? }
+        end
+      end
+    end
+
+    describe "with valid input (array)" do
+      let(:input) { { "foo" => ["23"] } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with valid input (hash)" do
+      let(:input) { { "foo" => { "bar" => "23" } } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is not successful" do
+        expect_not_successful result, ["is missing"]
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { "foo" => nil } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be filled"]
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { "foo" => "" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be filled"]
+      end
+    end
+
+    describe "with invalid input" do
+      let(:input) { { "foo" => [] } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be filled"]
+      end
+    end
+  end
+
+  describe "with optional" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations::Form
+
+        validations do
+          optional(:foo) { filled? }
+        end
+      end
+    end
+
+    describe "with valid input (array)" do
+      let(:input) { { "foo" => ["23"] } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with valid input (hash)" do
+      let(:input) { { "foo" => { "bar" => "23" } } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { "foo" => nil } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be filled"]
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { "foo" => "" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be filled"]
+      end
+    end
+
+    describe "with invalid input" do
+      let(:input) { { "foo" => [] } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be filled"]
+      end
+    end
+  end
+
+  describe "as macro" do
+    describe "with required" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              required(:foo).value(:filled?)
+            end
+          end
+        end
+
+        describe "with valid input (array)" do
+          let(:input) { { "foo" => ["23"] } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with valid input (hash)" do
+          let(:input) { { "foo" => { "bar" => "23" } } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { "foo" => [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              required(:foo).filled
+            end
+          end
+        end
+
+        describe "with valid input (array)" do
+          let(:input) { { "foo" => ["23"] } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with valid input (hash)" do
+          let(:input) { { "foo" => { "bar" => "23" } } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { "foo" => [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              required(:foo).maybe(:filled?)
+            end
+          end
+        end
+
+        describe "with valid input (array)" do
+          let(:input) { { "foo" => ["23"] } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with valid input (hash)" do
+          let(:input) { { "foo" => { "bar" => "23" } } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { "foo" => [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+      end
+    end
+
+    describe "with optional" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              optional(:foo).value(:filled?)
+            end
+          end
+        end
+
+        describe "with valid input (array)" do
+          let(:input) { { "foo" => ["23"] } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with valid input (hash)" do
+          let(:input) { { "foo" => { "bar" => "23" } } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { "foo" => [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              optional(:foo).filled
+            end
+          end
+        end
+
+        describe "with valid input (array)" do
+          let(:input) { { "foo" => ["23"] } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with valid input (hash)" do
+          let(:input) { { "foo" => { "bar" => "23" } } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { "foo" => [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              optional(:foo).maybe(:filled?)
+            end
+          end
+        end
+
+        describe "with valid input (array)" do
+          let(:input) { { "foo" => ["23"] } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with valid input (hash)" do
+          let(:input) { { "foo" => { "bar" => "23" } } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { "foo" => [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/validations/predicates/form/format_spec.rb
+++ b/spec/unit/hanami/validations/predicates/form/format_spec.rb
@@ -1,0 +1,494 @@
+# frozen_string_literal: true
+
+RSpec.describe "Predicates: Format" do
+  include_context "validator result"
+
+  describe "with required" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations::Form
+
+        validations do
+          required(:foo) { format?(/bar/) }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { "foo" => "bar baz" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      # FIXME: dry-v ticket: has an invalid format
+      it "is not successful" do
+        expect_not_successful result, ["is missing"]
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { "foo" => nil } }
+
+      it "is not successful" do
+        expect_not_successful result, ["is in invalid format"]
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { "foo" => "" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["is in invalid format"]
+      end
+    end
+
+    describe "with invalid type" do
+      let(:input) { { "foo" => { "a" => "1" } } }
+
+      it "raises error" do
+        expect { result }.to raise_error TypeError
+      end
+    end
+
+    describe "with invalid input" do
+      let(:input) { { "foo" => "wat" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["is in invalid format"]
+      end
+    end
+  end
+
+  describe "with optional" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations::Form
+
+        validations do
+          optional(:foo) { format?(/bar/) }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { "foo" => "bar baz" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { "foo" => nil } }
+
+      it "is not successful" do
+        expect_not_successful result, ["is in invalid format"]
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { "foo" => "" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["is in invalid format"]
+      end
+    end
+
+    describe "with invalid type" do
+      let(:input) { { "foo" => { "a" => "1" } } }
+
+      it "raises error" do
+        expect { result }.to raise_error TypeError
+      end
+    end
+
+    describe "with invalid input" do
+      let(:input) { { "foo" => "wat" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["is in invalid format"]
+      end
+    end
+  end
+
+  describe "as macro" do
+    describe "with required" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              required(:foo).value(format?: /bar/)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "bar baz" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["is in invalid format"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["is in invalid format"]
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { "foo" => { "a" => "1" } } }
+
+          it "raises error" do
+            expect { result }.to raise_error TypeError
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { "foo" => "wat" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["is in invalid format"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              required(:foo).filled(format?: /bar/)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "bar baz" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { "foo" => { "a" => "1" } } }
+
+          it "raises error" do
+            expect { result }.to raise_error TypeError
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { "foo" => "wat" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["is in invalid format"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              required(:foo).maybe(format?: /bar/)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "bar baz" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { "foo" => { "a" => "1" } } }
+
+          it "is not successful"
+          # it 'is not successful' do
+          #   expect_not_successful result, ['is in invalid format']
+          # end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { "foo" => "wat" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["is in invalid format"]
+          end
+        end
+      end
+    end
+
+    describe "with optional" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              optional(:foo).value(format?: /bar/)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "bar baz" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["is in invalid format"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["is in invalid format"]
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { "foo" => { "a" => "1" } } }
+
+          it "raises error" do
+            expect { result }.to raise_error TypeError
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { "foo" => "wat" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["is in invalid format"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              optional(:foo).filled(format?: /bar/)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "bar baz" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { "foo" => { "a" => "1" } } }
+
+          it "raises error" do
+            expect { result }.to raise_error TypeError
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { "foo" => "wat" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["is in invalid format"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              optional(:foo).maybe(format?: /bar/)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "bar baz" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { "foo" => { "a" => "1" } } }
+
+          it "raises error"
+          # it 'raises error' do
+          #   expect { result }.to raise_error TypeError
+          # end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { "foo" => "wat" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["is in invalid format"]
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/validations/predicates/form/gt_spec.rb
+++ b/spec/unit/hanami/validations/predicates/form/gt_spec.rb
@@ -1,0 +1,555 @@
+# frozen_string_literal: true
+
+RSpec.describe "Predicates: Gt" do
+  include_context "validator result"
+
+  describe "with required" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations::Form
+
+        validations do
+          required(:foo) { int? & gt?(23) }
+        end
+      end
+    end
+
+    describe "with invalid input" do
+      let(:input) { { "foo" => "33" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is not successful" do
+        expect_not_successful result, ["is missing", "must be greater than 23"]
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { "foo" => nil } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be an integer", "must be greater than 23"]
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { "foo" => "" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be an integer", "must be greater than 23"]
+      end
+    end
+
+    describe "with invalid input type" do
+      let(:input) { { "foo" => [] } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be an integer", "must be greater than 23"]
+      end
+    end
+
+    describe "with equal input" do
+      let(:input) { { "foo" => "23" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be greater than 23"]
+      end
+    end
+
+    describe "with less than input" do
+      let(:input) { { "foo" => "0" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be greater than 23"]
+      end
+    end
+  end
+
+  describe "with optional" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations::Form
+
+        validations do
+          optional(:foo) { int? & gt?(23) }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { "foo" => "33" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { "foo" => nil } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be an integer", "must be greater than 23"]
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { "foo" => "" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be an integer", "must be greater than 23"]
+      end
+    end
+
+    describe "with invalid input type" do
+      let(:input) { { "foo" => [] } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be an integer", "must be greater than 23"]
+      end
+    end
+
+    describe "with equal input" do
+      let(:input) { { "foo" => "23" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be greater than 23"]
+      end
+    end
+
+    describe "with less than input" do
+      let(:input) { { "foo" => "0" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be greater than 23"]
+      end
+    end
+  end
+
+  describe "as macro" do
+    describe "with required" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              required(:foo).value(:int?, gt?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "33" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be greater than 23"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be an integer", "must be greater than 23"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be an integer", "must be greater than 23"]
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { "foo" => [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be an integer", "must be greater than 23"]
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { "foo" => "23" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be greater than 23"]
+          end
+        end
+
+        describe "with less than input" do
+          let(:input) { { "foo" => "0" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be greater than 23"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              required(:foo).filled(:int?, gt?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "33" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be greater than 23"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be greater than 23"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be greater than 23"]
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { "foo" => [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be greater than 23"]
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { "foo" => "23" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be greater than 23"]
+          end
+        end
+
+        describe "with less than input" do
+          let(:input) { { "foo" => "0" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be greater than 23"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              required(:foo).maybe(:int?, gt?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => 33 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be greater than 23"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { "foo" => [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be an integer", "must be greater than 23"]
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { "foo" => "23" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be greater than 23"]
+          end
+        end
+
+        describe "with less than input" do
+          let(:input) { { "foo" => "0" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be greater than 23"]
+          end
+        end
+      end
+    end
+
+    describe "with optional" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              optional(:foo).value(:int?, gt?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "33" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be an integer", "must be greater than 23"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be an integer", "must be greater than 23"]
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { "foo" => [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be an integer", "must be greater than 23"]
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { "foo" => "23" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be greater than 23"]
+          end
+        end
+
+        describe "with less than input" do
+          let(:input) { { "foo" => "0" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be greater than 23"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              optional(:foo).filled(:int?, gt?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "33" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be greater than 23"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be greater than 23"]
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { "foo" => [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be greater than 23"]
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { "foo" => "23" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be greater than 23"]
+          end
+        end
+
+        describe "with less than input" do
+          let(:input) { { "foo" => "0" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be greater than 23"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              optional(:foo).maybe(:int?, gt?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "33" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { "foo" => [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be an integer", "must be greater than 23"]
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { "foo" => "23" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be greater than 23"]
+          end
+        end
+
+        describe "with less than input" do
+          let(:input) { { "foo" => "0" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be greater than 23"]
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/validations/predicates/form/gteq_spec.rb
+++ b/spec/unit/hanami/validations/predicates/form/gteq_spec.rb
@@ -1,0 +1,555 @@
+# frozen_string_literal: true
+
+RSpec.describe "Predicates: Gteq" do
+  include_context "validator result"
+
+  describe "with required" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations::Form
+
+        validations do
+          required(:foo) { int? & gteq?(23) }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { "foo" => "33" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is not successful" do
+        expect_not_successful result, ["is missing", "must be greater than or equal to 23"]
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { "foo" => nil } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be an integer", "must be greater than or equal to 23"]
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { "foo" => "" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be an integer", "must be greater than or equal to 23"]
+      end
+    end
+
+    describe "with invalid input type" do
+      let(:input) { { "foo" => [] } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be an integer", "must be greater than or equal to 23"]
+      end
+    end
+
+    describe "with equal input" do
+      let(:input) { { "foo" => "23" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with less than input" do
+      let(:input) { { "foo" => "0" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be greater than or equal to 23"]
+      end
+    end
+  end
+
+  describe "with optional" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations::Form
+
+        validations do
+          optional(:foo) { int? & gteq?(23) }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { "foo" => "33" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { "foo" => nil } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be an integer", "must be greater than or equal to 23"]
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { "foo" => "" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be an integer", "must be greater than or equal to 23"]
+      end
+    end
+
+    describe "with invalid input type" do
+      let(:input) { { "foo" => [] } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be an integer", "must be greater than or equal to 23"]
+      end
+    end
+
+    describe "with equal input" do
+      let(:input) { { "foo" => "23" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with less than input" do
+      let(:input) { { "foo" => "0" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be greater than or equal to 23"]
+      end
+    end
+  end
+
+  describe "as macro" do
+    describe "with required" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              required(:foo).value(:int?, gteq?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "33" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be greater than or equal to 23"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be an integer", "must be greater than or equal to 23"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be an integer", "must be greater than or equal to 23"]
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { "foo" => [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be an integer", "must be greater than or equal to 23"]
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { "foo" => "23" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with less than input" do
+          let(:input) { { "foo" => "0" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be greater than or equal to 23"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              required(:foo).filled(:int?, gteq?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "33" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be greater than or equal to 23"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be greater than or equal to 23"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be greater than or equal to 23"]
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { "foo" => [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be greater than or equal to 23"]
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { "foo" => "23" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with less than input" do
+          let(:input) { { "foo" => "0" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be greater than or equal to 23"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              required(:foo).maybe(:int?, gteq?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "33" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be greater than or equal to 23"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { "foo" => [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be an integer", "must be greater than or equal to 23"]
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { "foo" => "23" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with less than input" do
+          let(:input) { { "foo" => "0" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be greater than or equal to 23"]
+          end
+        end
+      end
+    end
+
+    describe "with optional" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              optional(:foo).value(:int?, gteq?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "33" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be an integer", "must be greater than or equal to 23"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be an integer", "must be greater than or equal to 23"]
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { "foo" => [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be an integer", "must be greater than or equal to 23"]
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { "foo" => "23" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with less than input" do
+          let(:input) { { "foo" => "0" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be greater than or equal to 23"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              optional(:foo).filled(:int?, gteq?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "33" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be greater than or equal to 23"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be greater than or equal to 23"]
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { "foo" => [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be greater than or equal to 23"]
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { "foo" => "23" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with less than input" do
+          let(:input) { { "foo" => "0" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be greater than or equal to 23"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              optional(:foo).maybe(:int?, gteq?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "33" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { "foo" => [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be an integer", "must be greater than or equal to 23"]
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { "foo" => "23" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with less than input" do
+          let(:input) { { "foo" => "0" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be greater than or equal to 23"]
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/validations/predicates/form/included_in_spec.rb
+++ b/spec/unit/hanami/validations/predicates/form/included_in_spec.rb
@@ -1,0 +1,491 @@
+# frozen_string_literal: true
+
+RSpec.describe "Predicates: Included In" do
+  include_context "validator result"
+
+  describe "with required" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations::Form
+
+        validations do
+          required(:foo) { included_in?(%w[1 3 5]) }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { "foo" => "3" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is not successful" do
+        expect_not_successful result, ["is missing", "must be one of: 1, 3, 5"]
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { "foo" => nil } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be one of: 1, 3, 5"]
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { "foo" => "" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be one of: 1, 3, 5"]
+      end
+    end
+
+    describe "with invalid type" do
+      let(:input) { { "foo" => { "a" => "1" } } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be one of: 1, 3, 5"]
+      end
+    end
+
+    describe "with invalid input" do
+      let(:input) { { "foo" => "4" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be one of: 1, 3, 5"]
+      end
+    end
+  end
+
+  describe "with optional" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations::Form
+
+        validations do
+          optional(:foo) { included_in?(%w[1 3 5]) }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { "foo" => "3" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { "foo" => nil } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be one of: 1, 3, 5"]
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { "foo" => "" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be one of: 1, 3, 5"]
+      end
+    end
+
+    describe "with invalid type" do
+      let(:input) { { "foo" => { "a" => "1" } } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be one of: 1, 3, 5"]
+      end
+    end
+
+    describe "with invalid input" do
+      let(:input) { { "foo" => "4" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be one of: 1, 3, 5"]
+      end
+    end
+  end
+
+  describe "as macro" do
+    describe "with required" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              required(:foo).value(included_in?: %w[1 3 5])
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "3" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { "foo" => { "a" => "1" } } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { "foo" => "4" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be one of: 1, 3, 5"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              required(:foo).filled(included_in?: %w[1 3 5])
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "3" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { "foo" => { "a" => "1" } } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { "foo" => "4" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be one of: 1, 3, 5"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              required(:foo).maybe(included_in?: %w[1 3 5])
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "3" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { "foo" => { "a" => "1" } } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { "foo" => "4" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be one of: 1, 3, 5"]
+          end
+        end
+      end
+    end
+
+    describe "with optional" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              optional(:foo).value(included_in?: %w[1 3 5])
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "3" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { "foo" => { "a" => "1" } } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { "foo" => "4" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be one of: 1, 3, 5"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              optional(:foo).filled(included_in?: %w[1 3 5])
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "3" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { "foo" => { "a" => "1" } } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { "foo" => "4" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be one of: 1, 3, 5"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              optional(:foo).maybe(included_in?: %w[1 3 5])
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "3" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { "foo" => { "a" => "1" } } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { "foo" => "4" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be one of: 1, 3, 5"]
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/validations/predicates/form/lt_spec.rb
+++ b/spec/unit/hanami/validations/predicates/form/lt_spec.rb
@@ -1,0 +1,555 @@
+# frozen_string_literal: true
+
+RSpec.describe "Predicates: Lt" do
+  include_context "validator result"
+
+  describe "with required" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations::Form
+
+        validations do
+          required(:foo) { int? & lt?(23) }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { "foo" => "1" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is not successful" do
+        expect_not_successful result, ["is missing", "must be less than 23"]
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { "foo" => nil } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be an integer", "must be less than 23"]
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { "foo" => "" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be an integer", "must be less than 23"]
+      end
+    end
+
+    describe "with invalid input type" do
+      let(:input) { { "foo" => [] } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be an integer", "must be less than 23"]
+      end
+    end
+
+    describe "with equal input" do
+      let(:input) { { "foo" => "23" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be less than 23"]
+      end
+    end
+
+    describe "with greater than input" do
+      let(:input) { { "foo" => "99" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be less than 23"]
+      end
+    end
+  end
+
+  describe "with optional" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations::Form
+
+        validations do
+          optional(:foo) { int? & lt?(23) }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { "foo" => "1" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { "foo" => nil } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be an integer", "must be less than 23"]
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { "foo" => "" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be an integer", "must be less than 23"]
+      end
+    end
+
+    describe "with invalid input type" do
+      let(:input) { { "foo" => [] } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be an integer", "must be less than 23"]
+      end
+    end
+
+    describe "with equal input" do
+      let(:input) { { "foo" => "23" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be less than 23"]
+      end
+    end
+
+    describe "with greater than input" do
+      let(:input) { { "foo" => "99" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be less than 23"]
+      end
+    end
+  end
+
+  describe "as macro" do
+    describe "with required" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              required(:foo).value(:int?, lt?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "1" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be less than 23"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be an integer", "must be less than 23"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be an integer", "must be less than 23"]
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { "foo" => [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be an integer", "must be less than 23"]
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { "foo" => "23" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be less than 23"]
+          end
+        end
+
+        describe "with greater than input" do
+          let(:input) { { "foo" => "99" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be less than 23"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              required(:foo).filled(:int?, lt?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "1" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be less than 23"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be less than 23"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be less than 23"]
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { "foo" => [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be less than 23"]
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { "foo" => "23" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be less than 23"]
+          end
+        end
+
+        describe "with greater than input" do
+          let(:input) { { "foo" => "99" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be less than 23"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              required(:foo).maybe(:int?, lt?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "1" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be less than 23"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { "foo" => [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be an integer", "must be less than 23"]
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { "foo" => "23" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be less than 23"]
+          end
+        end
+
+        describe "with greater than input" do
+          let(:input) { { "foo" => "99" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be less than 23"]
+          end
+        end
+      end
+    end
+
+    describe "with optional" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              optional(:foo).value(:int?, lt?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "1" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be an integer", "must be less than 23"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be an integer", "must be less than 23"]
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { "foo" => [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be an integer", "must be less than 23"]
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { "foo" => "23" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be less than 23"]
+          end
+        end
+
+        describe "with greater than input" do
+          let(:input) { { "foo" => "99" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be less than 23"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              optional(:foo).filled(:int?, lt?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "1" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be less than 23"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be less than 23"]
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { "foo" => [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be less than 23"]
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { "foo" => "23" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be less than 23"]
+          end
+        end
+
+        describe "with greater than input" do
+          let(:input) { { "foo" => "99" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be less than 23"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              optional(:foo).maybe(:int?, lt?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "1" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is successful" do
+            expect_successful result, []
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { "foo" => [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be an integer", "must be less than 23"]
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { "foo" => "23" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be less than 23"]
+          end
+        end
+
+        describe "with greater than input" do
+          let(:input) { { "foo" => "99" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be less than 23"]
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/validations/predicates/form/lteq_spec.rb
+++ b/spec/unit/hanami/validations/predicates/form/lteq_spec.rb
@@ -1,0 +1,555 @@
+# frozen_string_literal: true
+
+RSpec.describe "Predicates: Lteq" do
+  include_context "validator result"
+
+  describe "with required" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations::Form
+
+        validations do
+          required(:foo) { int? & lteq?(23) }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { "foo" => "1" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is not successful" do
+        expect_not_successful result, ["is missing", "must be less than or equal to 23"]
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { "foo" => nil } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be an integer", "must be less than or equal to 23"]
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { "foo" => "" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be an integer", "must be less than or equal to 23"]
+      end
+    end
+
+    describe "with invalid input type" do
+      let(:input) { { "foo" => [] } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be an integer", "must be less than or equal to 23"]
+      end
+    end
+
+    describe "with equal input" do
+      let(:input) { { "foo" => "23" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with greater than input" do
+      let(:input) { { "foo" => "99" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be less than or equal to 23"]
+      end
+    end
+  end
+
+  describe "with optional" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations::Form
+
+        validations do
+          optional(:foo) { int? & lteq?(23) }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { "foo" => "1" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { "foo" => nil } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be an integer", "must be less than or equal to 23"]
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { "foo" => "" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be an integer", "must be less than or equal to 23"]
+      end
+    end
+
+    describe "with invalid input type" do
+      let(:input) { { "foo" => [] } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be an integer", "must be less than or equal to 23"]
+      end
+    end
+
+    describe "with equal input" do
+      let(:input) { { "foo" => "23" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with greater than input" do
+      let(:input) { { "foo" => "99" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be less than or equal to 23"]
+      end
+    end
+  end
+
+  describe "as macro" do
+    describe "with required" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              required(:foo).value(:int?, lteq?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "1" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be less than or equal to 23"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be an integer", "must be less than or equal to 23"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be an integer", "must be less than or equal to 23"]
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { "foo" => [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be an integer", "must be less than or equal to 23"]
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { "foo" => "23" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with greater than input" do
+          let(:input) { { "foo" => "99" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be less than or equal to 23"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              required(:foo).filled(:int?, lteq?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "1" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be less than or equal to 23"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be less than or equal to 23"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be less than or equal to 23"]
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { "foo" => [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be less than or equal to 23"]
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { "foo" => "23" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with greater than input" do
+          let(:input) { { "foo" => "99" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be less than or equal to 23"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              required(:foo).maybe(:int?, lteq?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "1" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be less than or equal to 23"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { "foo" => [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be an integer", "must be less than or equal to 23"]
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { "foo" => "23" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with greater than input" do
+          let(:input) { { "foo" => "99" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be less than or equal to 23"]
+          end
+        end
+      end
+    end
+
+    describe "with optional" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              optional(:foo).value(:int?, lteq?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "1" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be an integer", "must be less than or equal to 23"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be an integer", "must be less than or equal to 23"]
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { "foo" => [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be an integer", "must be less than or equal to 23"]
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { "foo" => "23" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with greater than input" do
+          let(:input) { { "foo" => "99" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be less than or equal to 23"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              optional(:foo).filled(:int?, lteq?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "1" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be less than or equal to 23"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be less than or equal to 23"]
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { "foo" => [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be less than or equal to 23"]
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { "foo" => "23" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with greater than input" do
+          let(:input) { { "foo" => "99" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be less than or equal to 23"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              optional(:foo).maybe(:int?, lteq?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "1" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { "foo" => [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be an integer", "must be less than or equal to 23"]
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { "foo" => "23" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with greater than input" do
+          let(:input) { { "foo" => "99" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be less than or equal to 23"]
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/validations/predicates/form/max_size_spec.rb
+++ b/spec/unit/hanami/validations/predicates/form/max_size_spec.rb
@@ -1,0 +1,427 @@
+# frozen_string_literal: true
+
+RSpec.describe "Predicates: Max Size" do
+  include_context "validator result"
+
+  describe "with required" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations::Form
+
+        validations do
+          required(:foo) { max_size?(3) }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { "foo" => %w[1 2 3] } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is not successful" do
+        expect_not_successful result, ["is missing", "size cannot be greater than 3"]
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { "foo" => nil } }
+
+      it "is raises error" do
+        expect { result }.to raise_error(NoMethodError)
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { "foo" => "" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with invalid input" do
+      let(:input) { { "foo" => { "a" => "1", "b" => "2", "c" => "3", "d" => "4" } } }
+
+      it "is not successful" do
+        expect_not_successful result, ["size cannot be greater than 3"]
+      end
+    end
+  end
+
+  describe "with optional" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations::Form
+
+        validations do
+          optional(:foo) { max_size?(3) }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { "foo" => %w[1 2 3] } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { "foo" => nil } }
+
+      it "is raises error" do
+        expect { result }.to raise_error(NoMethodError)
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { "foo" => "" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with invalid input" do
+      let(:input) { { "foo" => { "a" => "1", "b" => "2", "c" => "3", "d" => "4" } } }
+
+      it "is not successful" do
+        expect_not_successful result, ["size cannot be greater than 3"]
+      end
+    end
+  end
+
+  describe "as macro" do
+    describe "with required" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              required(:foo).value(max_size?: 3)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => %w[1 2 3] } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "size cannot be greater than 3"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect { result }.to raise_error(NoMethodError)
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { "foo" => { "a" => "1", "b" => "2", "c" => "3", "d" => "4" } } }
+
+          it "is not successful" do
+            expect_not_successful result, ["size cannot be greater than 3"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              required(:foo).filled(max_size?: 3)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => %w[1 2 3] } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "size cannot be greater than 3"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "size cannot be greater than 3"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "size cannot be greater than 3"]
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { "foo" => { "a" => "1", "b" => "2", "c" => "3", "d" => "4" } } }
+
+          it "is not successful" do
+            expect_not_successful result, ["size cannot be greater than 3"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              required(:foo).maybe(max_size?: 3)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => %w[1 2 3] } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "size cannot be greater than 3"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { "foo" => { "a" => "1", "b" => "2", "c" => "3", "d" => "4" } } }
+
+          it "is not successful" do
+            expect_not_successful result, ["size cannot be greater than 3"]
+          end
+        end
+      end
+    end
+
+    describe "with optional" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              optional(:foo).value(max_size?: 3)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => %w[1 2 3] } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is raises error" do
+            expect { result }.to raise_error(NoMethodError)
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { "foo" => { "a" => "1", "b" => "2", "c" => "3", "d" => "4" } } }
+
+          it "is not successful" do
+            expect_not_successful result, ["size cannot be greater than 3"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              optional(:foo).filled(max_size?: 3)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => %w[1 2 3] } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "size cannot be greater than 3"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "size cannot be greater than 3"]
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { "foo" => { "a" => "1", "b" => "2", "c" => "3", "d" => "4" } } }
+
+          it "is not successful" do
+            expect_not_successful result, ["size cannot be greater than 3"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              optional(:foo).maybe(max_size?: 3)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => %w([1 2 3) } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { "foo" => { "a" => "1", "b" => "2", "c" => "3", "d" => "4" } } }
+
+          it "is not successful" do
+            expect_not_successful result, ["size cannot be greater than 3"]
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/validations/predicates/form/min_size_spec.rb
+++ b/spec/unit/hanami/validations/predicates/form/min_size_spec.rb
@@ -1,0 +1,427 @@
+# frozen_string_literal: true
+
+RSpec.describe "Predicates: Min Size" do
+  include_context "validator result"
+
+  describe "with required" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations::Form
+
+        validations do
+          required(:foo) { min_size?(3) }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { "foo" => %w[1 2 3] } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is not successful" do
+        expect_not_successful result, ["is missing", "size cannot be less than 3"]
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { "foo" => nil } }
+
+      it "is raises error" do
+        expect { result }.to raise_error(NoMethodError)
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { "foo" => "" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["size cannot be less than 3"]
+      end
+    end
+
+    describe "with invalid input" do
+      let(:input) { { "foo" => { "a" => "1", "b" => "2" } } }
+
+      it "is not successful" do
+        expect_not_successful result, ["size cannot be less than 3"]
+      end
+    end
+  end
+
+  describe "with optional" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations::Form
+
+        validations do
+          optional(:foo) { min_size?(3) }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { "foo" => %w[1 2 3] } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { "foo" => nil } }
+
+      it "is raises error" do
+        expect { result }.to raise_error(NoMethodError)
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { "foo" => "" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["size cannot be less than 3"]
+      end
+    end
+
+    describe "with invalid input" do
+      let(:input) { { "foo" => { "a" => "1", "b" => "2" } } }
+
+      it "is not successful" do
+        expect_not_successful result, ["size cannot be less than 3"]
+      end
+    end
+  end
+
+  describe "as macro" do
+    describe "with required" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              required(:foo).value(min_size?: 3)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => %w[1 2 3] } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "size cannot be less than 3"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is raises error" do
+            expect { result }.to raise_error(NoMethodError)
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["size cannot be less than 3"]
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { "foo" => { "a" => "1", "b" => "2" } } }
+
+          it "is not successful" do
+            expect_not_successful result, ["size cannot be less than 3"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              required(:foo).filled(min_size?: 3)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => %w[1 2 3] } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "size cannot be less than 3"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "size cannot be less than 3"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "size cannot be less than 3"]
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { "foo" => { "a" => "1", "b" => "2" } } }
+
+          it "is not successful" do
+            expect_not_successful result, ["size cannot be less than 3"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              required(:foo).maybe(min_size?: 3)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => %w[1 2 3] } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "size cannot be less than 3"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { "foo" => { "a" => "1", "b" => "2" } } }
+
+          it "is not successful" do
+            expect_not_successful result, ["size cannot be less than 3"]
+          end
+        end
+      end
+    end
+
+    describe "with optional" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              optional(:foo).value(min_size?: 3)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => %w[1 2 3] } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is raises error" do
+            expect { result }.to raise_error(NoMethodError)
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["size cannot be less than 3"]
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { "foo" => { "a" => "1", "b" => "2" } } }
+
+          it "is not successful" do
+            expect_not_successful result, ["size cannot be less than 3"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              optional(:foo).filled(min_size?: 3)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => %w[1 2 3] } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "size cannot be less than 3"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "size cannot be less than 3"]
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { "foo" => { "a" => "1", "b" => "2" } } }
+
+          it "is not successful" do
+            expect_not_successful result, ["size cannot be less than 3"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              optional(:foo).maybe(min_size?: 3)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => %w[1 2 3] } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { "foo" => { "a" => "1", "b" => "2" } } }
+
+          it "is not successful" do
+            expect_not_successful result, ["size cannot be less than 3"]
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/validations/predicates/form/none_spec.rb
+++ b/spec/unit/hanami/validations/predicates/form/none_spec.rb
@@ -1,0 +1,261 @@
+# frozen_string_literal: true
+
+RSpec.describe "Predicates: None" do
+  include_context "validator result"
+
+  describe "with required" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations::Form
+
+        validations do
+          required(:foo) { none? }
+        end
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is not successful" do
+        expect_not_successful result, ["is missing"]
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { "foo" => nil } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { "foo" => "" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with other input" do
+      let(:input) { { "foo" => "23" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["cannot be defined"]
+      end
+    end
+  end
+
+  describe "with optional" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations::Form
+
+        validations do
+          optional(:foo) { none? }
+        end
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { "foo" => nil } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { "foo" => "" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with other input" do
+      let(:input) { { "foo" => "23" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["cannot be defined"]
+      end
+    end
+  end
+
+  describe "as macro" do
+    describe "with required" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              required(:foo).value(:none?)
+            end
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with other input" do
+          let(:input) { { "foo" => "23" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["cannot be defined"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              required(:foo).filled(:none?)
+            end
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+
+        describe "with other input" do
+          let(:input) { { "foo" => "23" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["cannot be defined"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        # it doesn't make sense to ask for a required key and at the same time assert it's none
+        #
+        # Example:
+        #
+        #   validations do
+        #     required(:foo).maybe(:none?)
+        #   end
+      end
+    end
+
+    describe "with optional" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              optional(:foo).value(:none?)
+            end
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is  successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with other input" do
+          let(:input) { { "foo" => "23" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["cannot be defined"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        # it doesn't make sense to ask for a filled key and at the same time assert it's none
+        #
+        # Example:
+        #
+        #   validations do
+        #     optional(:foo).filled(:none?)
+        #   end
+      end
+
+      describe "with maybe" do
+        # it doesn't make sense to ask for a maybe key and at the same time assert it's none
+        #
+        # Example:
+        #
+        #   validations do
+        #     optional(:foo).maybe(:none?)
+        #   end
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/validations/predicates/form/size/fixed_test.rb
+++ b/spec/unit/hanami/validations/predicates/form/size/fixed_test.rb
@@ -1,0 +1,431 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe "Predicates: Size" do
+  include TestUtils
+
+  describe "Fixed (integer)" do
+    describe "with required" do
+      before do
+        @validator = Class.new do
+          include Hanami::Validations::Form
+
+          validations do
+            required(:foo) { size?(3) }
+          end
+        end
+      end
+
+      describe "with valid input" do
+        let(:input) { { "foo" => %w[1 2 3] } }
+
+        it "is successful" do
+          expect_successful result
+        end
+      end
+
+      describe "with missing input" do
+        let(:input) { {} }
+
+        it "is not successful" do
+          expect_not_successful result, ["is missing", "size must be 3"]
+        end
+      end
+
+      describe "with nil input" do
+        let(:input) { { "foo" => nil } }
+
+        it "is raises error" do
+          -> { result }.must_raise(NoMethodError)
+        end
+      end
+
+      describe "with blank input" do
+        let(:input) { { "foo" => "" } }
+
+        it "is not successful" do
+          expect_not_successful result, ["length must be 3"]
+        end
+      end
+
+      describe "with invalid input" do
+        let(:input) { { "foo" => { "a" => "1", "b" => "2", "c" => "3", "d" => "4" } } }
+
+        it "is not successful" do
+          expect_not_successful result, ["size must be 3"]
+        end
+      end
+    end
+
+    describe "with optional" do
+      before do
+        @validator = Class.new do
+          include Hanami::Validations::Form
+
+          validations do
+            optional(:foo) { size?(3) }
+          end
+        end
+      end
+
+      describe "with valid input" do
+        let(:input) { { "foo" => %w[1 2 3] } }
+
+        it "is successful" do
+          expect_successful result
+        end
+      end
+
+      describe "with missing input" do
+        let(:input) { {} }
+
+        it "is successful" do
+          expect_successful result
+        end
+      end
+
+      describe "with nil input" do
+        let(:input) { { "foo" => nil } }
+
+        it "is raises error" do
+          -> { result }.must_raise(NoMethodError)
+        end
+      end
+
+      describe "with blank input" do
+        let(:input) { { "foo" => "" } }
+
+        it "is not successful" do
+          expect_not_successful result, ["length must be 3"]
+        end
+      end
+
+      describe "with invalid input" do
+        let(:input) { { "foo" => { "a" => "1", "b" => "2", "c" => "3", "d" => "4" } } }
+
+        it "is not successful" do
+          expect_not_successful result, ["size must be 3"]
+        end
+      end
+    end
+
+    describe "as macro" do
+      describe "with required" do
+        describe "with value" do
+          before do
+            @validator = Class.new do
+              include Hanami::Validations::Form
+
+              validations do
+                required(:foo).value(size?: 3)
+              end
+            end
+          end
+
+          describe "with valid input" do
+            let(:input) { { "foo" => %w[1 2 3] } }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with missing input" do
+            let(:input) { {} }
+
+            it "is not successful" do
+              expect_not_successful result, ["is missing", "size must be 3"]
+            end
+          end
+
+          describe "with nil input" do
+            let(:input) { { "foo" => nil } }
+
+            it "is raises error" do
+              -> { result }.must_raise(NoMethodError)
+            end
+          end
+
+          describe "with blank input" do
+            let(:input) { { "foo" => "" } }
+
+            it "is not successful" do
+              expect_not_successful result, ["length must be 3"]
+            end
+          end
+
+          describe "with invalid input" do
+            let(:input) { { "foo" => { "a" => "1", "b" => "2", "c" => "3", "d" => "4" } } }
+
+            it "is not successful" do
+              expect_not_successful result, ["size must be 3"]
+            end
+          end
+        end
+
+        describe "with filled" do
+          before do
+            @validator = Class.new do
+              include Hanami::Validations::Form
+
+              validations do
+                required(:foo).filled(size?: 3)
+              end
+            end
+          end
+
+          describe "with valid input" do
+            let(:input) { { "foo" => %w[1 2 3] } }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with missing input" do
+            let(:input) { {} }
+
+            it "is not successful" do
+              expect_not_successful result, ["is missing", "size must be 3"]
+            end
+          end
+
+          describe "with nil input" do
+            let(:input) { { "foo" => nil } }
+
+            it "is not successful" do
+              expect_not_successful result, ["must be filled", "size must be 3"]
+            end
+          end
+
+          describe "with blank input" do
+            let(:input) { { "foo" => "" } }
+
+            it "is not successful" do
+              expect_not_successful result, ["must be filled", "length must be 3"]
+            end
+          end
+
+          describe "with invalid input" do
+            let(:input) { { "foo" => { "a" => "1", "b" => "2", "c" => "3", "d" => "4" } } }
+
+            it "is not successful" do
+              expect_not_successful result, ["size must be 3"]
+            end
+          end
+        end
+
+        describe "with maybe" do
+          before do
+            @validator = Class.new do
+              include Hanami::Validations::Form
+
+              validations do
+                required(:foo).maybe(size?: 3)
+              end
+            end
+          end
+
+          describe "with valid input" do
+            let(:input) { { "foo" => %w[1 2 3] } }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with missing input" do
+            let(:input) { {} }
+
+            it "is not successful" do
+              expect_not_successful result, ["is missing", "size must be 3"]
+            end
+          end
+
+          describe "with nil input" do
+            let(:input) { { "foo" => nil } }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with blank input" do
+            let(:input) { { "foo" => "" } }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with invalid input" do
+            let(:input) { { "foo" => { "a" => "1", "b" => "2", "c" => "3", "d" => "4" } } }
+
+            it "is not successful" do
+              expect_not_successful result, ["size must be 3"]
+            end
+          end
+        end
+      end
+
+      describe "with optional" do
+        describe "with value" do
+          before do
+            @validator = Class.new do
+              include Hanami::Validations::Form
+
+              validations do
+                optional(:foo).value(size?: 3)
+              end
+            end
+          end
+
+          describe "with valid input" do
+            let(:input) { { "foo" => %w[1 2 3] } }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with missing input" do
+            let(:input) { {} }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with nil input" do
+            let(:input) { { "foo" => nil } }
+
+            it "is raises error" do
+              -> { result }.must_raise(NoMethodError)
+            end
+          end
+
+          describe "with blank input" do
+            let(:input) { { "foo" => "" } }
+
+            it "is not successful" do
+              expect_not_successful result, ["length must be 3"]
+            end
+          end
+
+          describe "with invalid input" do
+            let(:input) { { "foo" => { "a" => "1", "b" => "2", "c" => "3", "d" => "4" } } }
+
+            it "is not successful" do
+              expect_not_successful result, ["size must be 3"]
+            end
+          end
+        end
+
+        describe "with filled" do
+          before do
+            @validator = Class.new do
+              include Hanami::Validations::Form
+
+              validations do
+                optional(:foo).filled(size?: 3)
+              end
+            end
+          end
+
+          describe "with valid input" do
+            let(:input) { { "foo" => %w[1 2 3] } }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with missing input" do
+            let(:input) { {} }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with nil input" do
+            let(:input) { { "foo" => nil } }
+
+            it "is not successful" do
+              expect_not_successful result, ["must be filled", "size must be 3"]
+            end
+          end
+
+          describe "with blank input" do
+            let(:input) { { "foo" => "" } }
+
+            it "is not successful" do
+              expect_not_successful result, ["must be filled", "length must be 3"]
+            end
+          end
+
+          describe "with invalid input" do
+            let(:input) { { "foo" => { "a" => "1", "b" => "2", "c" => "3", "d" => "4" } } }
+
+            it "is not successful" do
+              expect_not_successful result, ["size must be 3"]
+            end
+          end
+        end
+
+        describe "with maybe" do
+          before do
+            @validator = Class.new do
+              include Hanami::Validations::Form
+
+              validations do
+                optional(:foo).maybe(size?: 3)
+              end
+            end
+          end
+
+          describe "with valid input" do
+            let(:input) { { "foo" => %w[1 2 3] } }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with missing input" do
+            let(:input) { {} }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with nil input" do
+            let(:input) { { "foo" => nil } }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with blank input" do
+            let(:input) { { "foo" => "" } }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with invalid input" do
+            let(:input) { { "foo" => { "a" => "1", "b" => "2", "c" => "3", "d" => "4" } } }
+
+            it "is not successful" do
+              expect_not_successful result, ["size must be 3"]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/validations/predicates/form/size/range_test.rb
+++ b/spec/unit/hanami/validations/predicates/form/size/range_test.rb
@@ -1,0 +1,431 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe "Predicates: Size" do
+  include TestUtils
+
+  describe "Range" do
+    describe "with required" do
+      before do
+        @validator = Class.new do
+          include Hanami::Validations::Form
+
+          validations do
+            required(:foo) { size?(2..3) }
+          end
+        end
+      end
+
+      describe "with valid input" do
+        let(:input) { { "foo" => %w[1 2 3] } }
+
+        it "is successful" do
+          expect_successful result
+        end
+      end
+
+      describe "with missing input" do
+        let(:input) { {} }
+
+        it "is not successful" do
+          expect_not_successful result, ["is missing", "size must be within 2 - 3"]
+        end
+      end
+
+      describe "with nil input" do
+        let(:input) { { "foo" => nil } }
+
+        it "is raises error" do
+          -> { result }.must_raise(NoMethodError)
+        end
+      end
+
+      describe "with blank input" do
+        let(:input) { { "foo" => "" } }
+
+        it "is not successful" do
+          expect_not_successful result, ["length must be within 2 - 3"]
+        end
+      end
+
+      describe "with invalid input" do
+        let(:input) { { "foo" => { "a" => "1", "b" => "2", "c" => "3", "d" => "4" } } }
+
+        it "is not successful" do
+          expect_not_successful result, ["size must be within 2 - 3"]
+        end
+      end
+    end
+
+    describe "with optional" do
+      before do
+        @validator = Class.new do
+          include Hanami::Validations::Form
+
+          validations do
+            optional(:foo) { size?(2..3) }
+          end
+        end
+      end
+
+      describe "with valid input" do
+        let(:input) { { "foo" => %w[1 2 3] } }
+
+        it "is successful" do
+          expect_successful result
+        end
+      end
+
+      describe "with missing input" do
+        let(:input) { {} }
+
+        it "is successful" do
+          expect_successful result
+        end
+      end
+
+      describe "with nil input" do
+        let(:input) { { "foo" => nil } }
+
+        it "is raises error" do
+          -> { result }.must_raise(NoMethodError)
+        end
+      end
+
+      describe "with blank input" do
+        let(:input) { { "foo" => "" } }
+
+        it "is not successful" do
+          expect_not_successful result, ["length must be within 2 - 3"]
+        end
+      end
+
+      describe "with invalid input" do
+        let(:input) { { "foo" => { "a" => "1", "b" => "2", "c" => "3", "d" => "4" } } }
+
+        it "is not successful" do
+          expect_not_successful result, ["size must be within 2 - 3"]
+        end
+      end
+    end
+
+    describe "as macro" do
+      describe "with required" do
+        describe "with value" do
+          before do
+            @validator = Class.new do
+              include Hanami::Validations::Form
+
+              validations do
+                required(:foo).value(size?: 2..3)
+              end
+            end
+          end
+
+          describe "with valid input" do
+            let(:input) { { "foo" => %w[1 2 3] } }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with missing input" do
+            let(:input) { {} }
+
+            it "is not successful" do
+              expect_not_successful result, ["is missing", "size must be within 2 - 3"]
+            end
+          end
+
+          describe "with nil input" do
+            let(:input) { { "foo" => nil } }
+
+            it "is raises error" do
+              -> { result }.must_raise(NoMethodError)
+            end
+          end
+
+          describe "with blank input" do
+            let(:input) { { "foo" => "" } }
+
+            it "is not successful" do
+              expect_not_successful result, ["length must be within 2 - 3"]
+            end
+          end
+
+          describe "with invalid input" do
+            let(:input) { { "foo" => { "a" => "1", "b" => "2", "c" => "3", "d" => "4" } } }
+
+            it "is not successful" do
+              expect_not_successful result, ["size must be within 2 - 3"]
+            end
+          end
+        end
+
+        describe "with filled" do
+          before do
+            @validator = Class.new do
+              include Hanami::Validations::Form
+
+              validations do
+                required(:foo).filled(size?: 2..3)
+              end
+            end
+          end
+
+          describe "with valid input" do
+            let(:input) { { "foo" => %w[1 2 3] } }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with missing input" do
+            let(:input) { {} }
+
+            it "is not successful" do
+              expect_not_successful result, ["is missing", "size must be within 2 - 3"]
+            end
+          end
+
+          describe "with nil input" do
+            let(:input) { { "foo" => nil } }
+
+            it "is not successful" do
+              expect_not_successful result, ["must be filled", "size must be within 2 - 3"]
+            end
+          end
+
+          describe "with blank input" do
+            let(:input) { { "foo" => "" } }
+
+            it "is not successful" do
+              expect_not_successful result, ["must be filled", "length must be within 2 - 3"]
+            end
+          end
+
+          describe "with invalid input" do
+            let(:input) { { "foo" => { "a" => "1", "b" => "2", "c" => "3", "d" => "4" } } }
+
+            it "is not successful" do
+              expect_not_successful result, ["size must be within 2 - 3"]
+            end
+          end
+        end
+
+        describe "with maybe" do
+          before do
+            @validator = Class.new do
+              include Hanami::Validations::Form
+
+              validations do
+                required(:foo).maybe(size?: 2..3)
+              end
+            end
+          end
+
+          describe "with valid input" do
+            let(:input) { { "foo" => %w[1 2 3] } }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with missing input" do
+            let(:input) { {} }
+
+            it "is not successful" do
+              expect_not_successful result, ["is missing", "size must be within 2 - 3"]
+            end
+          end
+
+          describe "with nil input" do
+            let(:input) { { "foo" => nil } }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with blank input" do
+            let(:input) { { "foo" => "" } }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with invalid input" do
+            let(:input) { { "foo" => { "a" => "1", "b" => "2", "c" => "3", "d" => "4" } } }
+
+            it "is not successful" do
+              expect_not_successful result, ["size must be within 2 - 3"]
+            end
+          end
+        end
+      end
+
+      describe "with optional" do
+        describe "with value" do
+          before do
+            @validator = Class.new do
+              include Hanami::Validations::Form
+
+              validations do
+                optional(:foo).value(size?: 2..3)
+              end
+            end
+          end
+
+          describe "with valid input" do
+            let(:input) { { "foo" => %w[1 2 3] } }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with missing input" do
+            let(:input) { {} }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with nil input" do
+            let(:input) { { "foo" => nil } }
+
+            it "is raises error" do
+              -> { result }.must_raise(NoMethodError)
+            end
+          end
+
+          describe "with blank input" do
+            let(:input) { { "foo" => "" } }
+
+            it "is not successful" do
+              expect_not_successful result, ["length must be within 2 - 3"]
+            end
+          end
+
+          describe "with invalid input" do
+            let(:input) { { "foo" => { "a" => "1", "b" => "2", "c" => "3", "d" => "4" } } }
+
+            it "is not successful" do
+              expect_not_successful result, ["size must be within 2 - 3"]
+            end
+          end
+        end
+
+        describe "with filled" do
+          before do
+            @validator = Class.new do
+              include Hanami::Validations::Form
+
+              validations do
+                optional(:foo).filled(size?: 2..3)
+              end
+            end
+          end
+
+          describe "with valid input" do
+            let(:input) { { "foo" => %w[1 2 3] } }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with missing input" do
+            let(:input) { {} }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with nil input" do
+            let(:input) { { "foo" => nil } }
+
+            it "is not successful" do
+              expect_not_successful result, ["must be filled", "size must be within 2 - 3"]
+            end
+          end
+
+          describe "with blank input" do
+            let(:input) { { "foo" => "" } }
+
+            it "is not successful" do
+              expect_not_successful result, ["must be filled", "length must be within 2 - 3"]
+            end
+          end
+
+          describe "with invalid input" do
+            let(:input) { { "foo" => { "a" => "1", "b" => "2", "c" => "3", "d" => "4" } } }
+
+            it "is not successful" do
+              expect_not_successful result, ["size must be within 2 - 3"]
+            end
+          end
+        end
+
+        describe "with maybe" do
+          before do
+            @validator = Class.new do
+              include Hanami::Validations::Form
+
+              validations do
+                optional(:foo).maybe(size?: 2..3)
+              end
+            end
+          end
+
+          describe "with valid input" do
+            let(:input) { { "foo" => %w[1 2 3] } }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with missing input" do
+            let(:input) { {} }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with nil input" do
+            let(:input) { { "foo" => nil } }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with blank input" do
+            let(:input) { { "foo" => "" } }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with invalid input" do
+            let(:input) { { "foo" => { "a" => "1", "b" => "2", "c" => "3", "d" => "4" } } }
+
+            it "is not successful" do
+              expect_not_successful result, ["size must be within 2 - 3"]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/validations/predicates/form/type_spec.rb
+++ b/spec/unit/hanami/validations/predicates/form/type_spec.rb
@@ -1,0 +1,427 @@
+# frozen_string_literal: true
+
+RSpec.describe "Predicates: Type" do
+  include_context "validator result"
+
+  describe "with required" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations::Form
+
+        validations do
+          required(:foo) { type?(Integer) }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { "foo" => "23" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is not successful" do
+        expect_not_successful result, ["is missing", "must be Integer"]
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { "foo" => nil } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be Integer"]
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { "foo" => "" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be Integer"]
+      end
+    end
+
+    describe "with invalid type" do
+      let(:input) { { "foo" => ["x"] } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be Integer"]
+      end
+    end
+  end
+
+  describe "with optional" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations::Form
+
+        validations do
+          optional(:foo) { type?(Integer) }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { "foo" => "23" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { "foo" => nil } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be Integer"]
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { "foo" => "" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be Integer"]
+      end
+    end
+
+    describe "with invalid type" do
+      let(:input) { { "foo" => ["x"] } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be Integer"]
+      end
+    end
+  end
+
+  describe "as macro" do
+    describe "with required" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              required(:foo).value(type?: Integer)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "23" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be Integer"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be Integer"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be Integer"]
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { "foo" => ["x"] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be Integer"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              required(:foo).filled(type?: Integer)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "23" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be Integer"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be Integer"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be Integer"]
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { "foo" => ["x"] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be Integer"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              required(:foo).maybe(type?: Integer)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "23" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be Integer"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { "foo" => ["x"] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be Integer"]
+          end
+        end
+      end
+    end
+
+    describe "with optional" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              optional(:foo).value(type?: Integer)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "23" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be Integer"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be Integer"]
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { "foo" => ["x"] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be Integer"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              optional(:foo).filled(type?: Integer)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "23" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be Integer"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be Integer"]
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { "foo" => ["x"] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be Integer"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations::Form
+
+            validations do
+              optional(:foo).maybe(type?: Integer)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { "foo" => "23" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { "foo" => nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { "foo" => "" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { "foo" => ["x"] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be Integer"]
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/validations/predicates/schema/array_spec.rb
+++ b/spec/unit/hanami/validations/predicates/schema/array_spec.rb
@@ -1,0 +1,250 @@
+# frozen_string_literal: true
+
+RSpec.describe "Predicates: Array" do
+  include_context "validator result"
+
+  describe "with required" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations
+
+        validations do
+          required(:foo) { array? { each { int? } } }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { foo: [3] } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is not successful" do
+        expect_not_successful(
+          result,
+          ["is missing"]
+        )
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { foo: nil } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be an array"]
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { foo: "" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be an array"]
+      end
+    end
+
+    describe "with invalid type" do
+      let(:input) { { foo: { a: 1 } } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be an array"]
+      end
+    end
+
+    describe "with invalid input (integer)" do
+      let(:input) { { foo: 4 } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be an array"]
+      end
+    end
+
+    describe "with invalid input (array with non-integers)" do
+      let(:input) { { foo: %i[foo bar] } }
+
+      it "is not successful" do
+        expect_not_successful result, 0 => ["must be an integer"], 1 => ["must be an integer"]
+      end
+    end
+
+    describe "with invalid input (miexed array)" do
+      let(:input) { { foo: [1, "2", :bar] } }
+
+      it "is not successful" do
+        expect_not_successful result, 1 => ["must be an integer"], 2 => ["must be an integer"]
+      end
+    end
+  end
+
+  describe "with optional" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations
+
+        validations do
+          optional(:foo) { included_in?([1, 3, 5]) }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { foo: 3 } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { foo: nil } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be one of: 1, 3, 5"]
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { foo: "" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be one of: 1, 3, 5"]
+      end
+    end
+
+    describe "with invalid type" do
+      let(:input) { { foo: { a: 1 } } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be one of: 1, 3, 5"]
+      end
+    end
+
+    describe "with invalid input" do
+      let(:input) { { foo: 4 } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be one of: 1, 3, 5"]
+      end
+    end
+  end
+
+  describe "as macro" do
+    describe "with required" do
+      before do
+        @validator = Class.new do
+          include Hanami::Validations
+
+          validations do
+            required(:foo).each(:int?)
+          end
+        end
+      end
+
+      describe "with missing input" do
+        let(:input) { {} }
+
+        it "is not successful" do
+          expect_not_successful result, ["is missing"]
+        end
+      end
+
+      describe "with nil input" do
+        let(:input) { { foo: nil } }
+
+        it "is not successful" do
+          expect_not_successful result, ["must be an array"]
+        end
+      end
+
+      describe "with blank input" do
+        let(:input) { { foo: "" } }
+
+        it "is not successful" do
+          expect_not_successful result, ["must be an array"]
+        end
+      end
+
+      describe "with valid input" do
+        let(:input) { { foo: [3] } }
+
+        it "is successful" do
+          expect_successful result
+        end
+      end
+
+      describe "with invalid input" do
+        let(:input) { { foo: [:bar] } }
+
+        it "is not successful" do
+          expect_not_successful result, 0 => ["must be an integer"]
+        end
+      end
+    end
+
+    describe "with optional" do
+      before do
+        @validator = Class.new do
+          include Hanami::Validations
+
+          validations do
+            optional(:foo).each(:int?)
+          end
+        end
+      end
+
+      describe "with missing input" do
+        let(:input) { {} }
+
+        it "is not successful" do
+          expect_successful result
+        end
+      end
+
+      describe "with nil input" do
+        let(:input) { { foo: nil } }
+
+        it "is not successful" do
+          expect_not_successful result, ["must be an array"]
+        end
+      end
+
+      describe "with blank input" do
+        let(:input) { { foo: "" } }
+
+        it "is not successful" do
+          expect_not_successful result, ["must be an array"]
+        end
+      end
+
+      describe "with valid input" do
+        let(:input) { { foo: [3] } }
+
+        it "is successful" do
+          expect_successful result
+        end
+      end
+
+      describe "with invalid input" do
+        let(:input) { { foo: [:bar] } }
+
+        it "is not successful" do
+          expect_not_successful result, 0 => ["must be an integer"]
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/validations/predicates/schema/custom_spec.rb
+++ b/spec/unit/hanami/validations/predicates/schema/custom_spec.rb
@@ -1,0 +1,202 @@
+# frozen_string_literal: true
+
+RSpec.describe "Predicates: custom" do
+  include_context "validator result"
+
+  describe "with custom predicate" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations
+
+        def self.name
+          "Validator"
+        end
+
+        validations do
+          configure do
+            config.messages_file = "spec/support/fixtures/messages.yml"
+
+            def email?(current)
+              current.match(/\@/)
+            end
+          end
+
+          required(:foo) { email? }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { foo: "test@hanamirb.org" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with invalid input" do
+      let(:input) { { foo: "test" } }
+
+      it "is successful" do
+        expect_not_successful result, ["must be an email"]
+      end
+    end
+  end
+
+  describe "with custom predicates as module" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations
+
+        def self.name
+          "Validator"
+        end
+
+        predicates(
+          Module.new do
+            include Hanami::Validations::Predicates
+            self.messages_path = "spec/support/fixtures/messages.yml"
+
+            predicate(:email?) do |current|
+              current.match(/@/)
+            end
+          end
+        )
+
+        validations do
+          required(:foo) { email? }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { foo: "test@hanamirb.org" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with invalid input" do
+      let(:input) { { foo: "test" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be an email"]
+      end
+    end
+  end
+
+  describe "with custom predicate within predicates block" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations
+
+        def self.name
+          "Validator"
+        end
+
+        predicate :url?, message: "must be an URL" do |current|
+          current.start_with?("http")
+        end
+
+        validations do
+          required(:foo) { url? }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { foo: "http://hanamirb.org" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with invalid input" do
+      let(:input) { { foo: "test" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be an URL"]
+      end
+    end
+  end
+
+  describe "without custom predicate" do
+    it "raises error if try to use an unknown predicate" do
+      expect do
+        Class.new do
+          include Hanami::Validations
+
+          def self.name
+            "Validator"
+          end
+
+          validations do
+            required(:foo) { email? }
+          end
+        end
+      end.to raise_error(ArgumentError, "+email?+ is not a valid predicate name")
+    end
+  end
+
+  # See: https://github.com/hanami/validations/issues/119
+  describe "with custom predicate and error messages" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations
+        messages_path "spec/support/fixtures/messages.yml"
+
+        predicate(:adult?, message: "not old enough") do |current|
+          current > 18
+        end
+
+        validations do
+          required(:name) { format?(/Frank/) }
+          required(:age)  { adult? }
+        end
+      end
+    end
+
+    it "respects messages from configuration file" do
+      result = @validator.new(name: "John", age: 15).validate
+
+      expect(result).not_to be_success
+      expect(result.messages[:name]).to eq ["must be frank"]
+      expect(result.messages[:age]).to eq ["not old enough"]
+    end
+  end
+
+  describe "with nested validations" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations
+
+        def self.name
+          "Validator"
+        end
+
+        validations do
+          required(:details).schema do
+            configure do
+              config.messages_file = "spec/support/fixtures/messages.yml"
+
+              def odd?(current)
+                current.odd?
+              end
+            end
+
+            required(:foo) { odd? }
+          end
+        end
+      end
+    end
+
+    it "allows groups to define their own custom predicates" do
+      result = @validator.new(details: { foo: 2 }).validate
+
+      expect(result).not_to be_success
+      expect(result.messages[:details][:foo]).to eq ["must be odd"]
+    end
+  end
+end

--- a/spec/unit/hanami/validations/predicates/schema/empty_spec.rb
+++ b/spec/unit/hanami/validations/predicates/schema/empty_spec.rb
@@ -1,0 +1,291 @@
+# frozen_string_literal: true
+
+RSpec.describe "Predicates: Empty" do
+  include_context "validator result"
+
+  describe "with required" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations
+
+        validations do
+          required(:foo) { empty? }
+        end
+      end
+    end
+
+    describe "with valid input (array)" do
+      let(:input) { { foo: [] } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with valid input (hash)" do
+      let(:input) { { foo: {} } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is not successful" do
+        expect_not_successful result, ["is missing", "must be empty"]
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { foo: nil } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { foo: "" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with invalid input" do
+      let(:input) { { foo: [23] } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be empty"]
+      end
+    end
+  end
+
+  describe "with optional" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations
+
+        validations do
+          optional(:foo) { empty? }
+        end
+      end
+    end
+
+    describe "with valid input (array)" do
+      let(:input) { { foo: [] } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with valid input (hash)" do
+      let(:input) { { foo: {} } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { foo: nil } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { foo: "" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with invalid input" do
+      let(:input) { { foo: [23] } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be empty"]
+      end
+    end
+  end
+
+  describe "as macro" do
+    describe "with required" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              required(:foo).value(:empty?)
+            end
+          end
+        end
+
+        describe "with valid input (array)" do
+          let(:input) { { foo: [] } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with valid input (hash)" do
+          let(:input) { { foo: {} } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be empty"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { foo: [23] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be empty"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        # it doesn't make sense to ask for a filled key and at the same time assert it's empty
+        #
+        # Example:
+        #
+        #   validations do
+        #     required(:foo).filled(:empty?)
+        #   end
+      end
+
+      describe "with maybe" do
+        # it doesn't make sense to ask for a filled key and at the same time assert it's empty
+        #
+        # Example:
+        #
+        #   validations do
+        #     required(:foo).maybe(:empty?)
+        #   end
+      end
+    end
+
+    describe "with optional" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              optional(:foo).value(:empty?)
+            end
+          end
+        end
+
+        describe "with valid input (array)" do
+          let(:input) { { foo: [] } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with valid input (hash)" do
+          let(:input) { { foo: {} } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { foo: [23] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be empty"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        # it doesn't make sense to ask for a filled key and at the same time assert it's empty
+        #
+        # Example:
+        #
+        #   validations do
+        #     optional(:foo).filled(:empty?)
+        #   end
+      end
+
+      describe "with maybe" do
+        # it doesn't make sense to ask for a maybe key and at the same time assert it's empty
+        #
+        # Example:
+        #
+        #   validations do
+        #     optional(:foo).filled(:empty?)
+        #   end
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/validations/predicates/schema/eql_spec.rb
+++ b/spec/unit/hanami/validations/predicates/schema/eql_spec.rb
@@ -1,0 +1,363 @@
+# frozen_string_literal: true
+
+RSpec.describe "Predicates: Eql" do
+  include_context "validator result"
+
+  describe "with required" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations
+
+        validations do
+          required(:foo) { eql?(23) }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { foo: 23 } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is not successful" do
+        expect_not_successful result, ["is missing", "must be equal to 23"]
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { foo: nil } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be equal to 23"]
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { foo: "" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be equal to 23"]
+      end
+    end
+  end
+
+  describe "with optional" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations
+
+        validations do
+          optional(:foo) { eql?(23) }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { foo: 23 } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { foo: nil } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be equal to 23"]
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { foo: "" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be equal to 23"]
+      end
+    end
+  end
+
+  describe "as macro" do
+    describe "with required" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              required(:foo).value(eql?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 23 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be equal to 23"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be equal to 23"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be equal to 23"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              required(:foo).filled(eql?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 23 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be equal to 23"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be equal to 23"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be equal to 23"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              required(:foo).maybe(eql?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 23 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be equal to 23"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be equal to 23"]
+          end
+        end
+      end
+    end
+
+    describe "with optional" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              optional(:foo).value(eql?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 23 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be equal to 23"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be equal to 23"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              optional(:foo).filled(eql?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 23 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be equal to 23"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be equal to 23"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              optional(:foo).maybe(eql?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 23 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be equal to 23"]
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/validations/predicates/schema/excluded_from_spec.rb
+++ b/spec/unit/hanami/validations/predicates/schema/excluded_from_spec.rb
@@ -1,0 +1,491 @@
+# frozen_string_literal: true
+
+RSpec.describe "Predicates: Excluded From" do
+  include_context "validator result"
+
+  describe "with required" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations
+
+        validations do
+          required(:foo) { excluded_from?([1, 3, 5]) }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { foo: 2 } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is not successful" do
+        expect_not_successful result, ["is missing", "must not be one of: 1, 3, 5"]
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { foo: nil } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { foo: "" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with invalid type" do
+      let(:input) { { foo: { a: 1 } } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with invalid input" do
+      let(:input) { { foo: 5 } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must not be one of: 1, 3, 5"]
+      end
+    end
+  end
+
+  describe "with optional" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations
+
+        validations do
+          optional(:foo) { excluded_from?([1, 3, 5]) }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { foo: 2 } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { foo: nil } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { foo: "" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with invalid type" do
+      let(:input) { { foo: { a: 1 } } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with invalid input" do
+      let(:input) { { foo: 5 } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must not be one of: 1, 3, 5"]
+      end
+    end
+  end
+
+  describe "as macro" do
+    describe "with required" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              required(:foo).value(excluded_from?: [1, 3, 5])
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 2 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must not be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { foo: { a: 1 } } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { foo: 5 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must not be one of: 1, 3, 5"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              required(:foo).filled(excluded_from?: [1, 3, 5])
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 2 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must not be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must not be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must not be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { foo: { a: 1 } } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { foo: 5 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must not be one of: 1, 3, 5"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              required(:foo).maybe(excluded_from?: [1, 3, 5])
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 2 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must not be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { foo: { a: 1 } } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { foo: 5 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must not be one of: 1, 3, 5"]
+          end
+        end
+      end
+    end
+
+    describe "with optional" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              optional(:foo).value(excluded_from?: [1, 3, 5])
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 2 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { foo: { a: 1 } } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { foo: 5 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must not be one of: 1, 3, 5"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              optional(:foo).filled(excluded_from?: [1, 3, 5])
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 2 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must not be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must not be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { foo: { a: 1 } } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { foo: 5 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must not be one of: 1, 3, 5"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              optional(:foo).maybe(excluded_from?: [1, 3, 5])
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 2 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { foo: { a: 1 } } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { foo: 5 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must not be one of: 1, 3, 5"]
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/validations/predicates/schema/filled_spec.rb
+++ b/spec/unit/hanami/validations/predicates/schema/filled_spec.rb
@@ -1,0 +1,491 @@
+# frozen_string_literal: true
+
+RSpec.describe "Predicates: Filled" do
+  include_context "validator result"
+
+  describe "with key" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations
+
+        validations do
+          required(:foo) { filled? }
+        end
+      end
+    end
+
+    describe "with valid input (array)" do
+      let(:input) { { foo: [23] } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with valid input (hash)" do
+      let(:input) { { foo: { bar: 23 } } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is not successful" do
+        expect_not_successful result, ["is missing"]
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { foo: nil } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be filled"]
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { foo: "" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be filled"]
+      end
+    end
+
+    describe "with invalid input" do
+      let(:input) { { foo: [] } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be filled"]
+      end
+    end
+  end
+
+  describe "with optional" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations
+
+        validations do
+          optional(:foo) { filled? }
+        end
+      end
+    end
+
+    describe "with valid input (array)" do
+      let(:input) { { foo: [23] } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with valid input (hash)" do
+      let(:input) { { foo: { bar: 23 } } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { foo: nil } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be filled"]
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { foo: "" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be filled"]
+      end
+    end
+
+    describe "with invalid input" do
+      let(:input) { { foo: [] } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be filled"]
+      end
+    end
+  end
+
+  describe "as macro" do
+    describe "with required" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              required(:foo).value(:filled?)
+            end
+          end
+        end
+
+        describe "with valid input (array)" do
+          let(:input) { { foo: [23] } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with valid input (hash)" do
+          let(:input) { { foo: { bar: 23 } } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { foo: [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              required(:foo).filled
+            end
+          end
+        end
+
+        describe "with valid input (array)" do
+          let(:input) { { foo: [23] } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with valid input (hash)" do
+          let(:input) { { foo: { bar: 23 } } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { foo: [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              required(:foo).maybe(:filled?)
+            end
+          end
+        end
+
+        describe "with valid input (array)" do
+          let(:input) { { foo: [23] } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with valid input (hash)" do
+          let(:input) { { foo: { bar: 23 } } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { foo: [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+      end
+    end
+
+    describe "with optional" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              optional(:foo).value(:filled?)
+            end
+          end
+        end
+
+        describe "with valid input (array)" do
+          let(:input) { { foo: [23] } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with valid input (hash)" do
+          let(:input) { { foo: { bar: 23 } } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { foo: [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              optional(:foo).filled
+            end
+          end
+        end
+
+        describe "with valid input (array)" do
+          let(:input) { { foo: [23] } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with valid input (hash)" do
+          let(:input) { { foo: { bar: 23 } } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { foo: [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              optional(:foo).maybe(:filled?)
+            end
+          end
+        end
+
+        describe "with valid input (array)" do
+          let(:input) { { foo: [23] } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with valid input (hash)" do
+          let(:input) { { foo: { bar: 23 } } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { foo: [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/validations/predicates/schema/format_spec.rb
+++ b/spec/unit/hanami/validations/predicates/schema/format_spec.rb
@@ -1,0 +1,492 @@
+# frozen_string_literal: true
+
+RSpec.describe "Predicates: Format" do
+  include_context "validator result"
+
+  describe "with required" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations
+
+        validations do
+          required(:foo) { format?(/bar/) }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { foo: "bar baz" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      # FIXME: dry-v ticket: has an invalid format
+      it "is not successful" do
+        expect_not_successful result, ["is missing"]
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { foo: nil } }
+
+      it "is not successful" do
+        expect_not_successful result, ["is in invalid format"]
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { foo: "" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["is in invalid format"]
+      end
+    end
+
+    describe "with invalid type" do
+      let(:input) { { foo: { a: 1 } } }
+
+      it "raises error" do
+        expect { result }.to raise_error TypeError
+      end
+    end
+
+    describe "with invalid input" do
+      let(:input) { { foo: "wat" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["is in invalid format"]
+      end
+    end
+  end
+
+  describe "with optional" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations
+
+        validations do
+          optional(:foo) { format?(/bar/) }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { foo: "bar baz" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { foo: nil } }
+
+      it "is not successful" do
+        expect_not_successful result, ["is in invalid format"]
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { foo: "" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["is in invalid format"]
+      end
+    end
+
+    describe "with invalid type" do
+      let(:input) { { foo: { a: 1 } } }
+
+      it "raises error" do
+        expect { result }.to raise_error TypeError
+      end
+    end
+
+    describe "with invalid input" do
+      let(:input) { { foo: "wat" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["is in invalid format"]
+      end
+    end
+  end
+
+  describe "as macro" do
+    describe "with required" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              required(:foo).value(format?: /bar/)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: "bar baz" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["is in invalid format"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["is in invalid format"]
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { foo: { a: 1 } } }
+
+          it "raises error" do
+            expect { result }.to raise_error TypeError
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { foo: "wat" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["is in invalid format"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              required(:foo).filled(format?: /bar/)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: "bar baz" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { foo: { a: 1 } } }
+
+          it "raises error" do
+            expect { result }.to raise_error TypeError
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { foo: "wat" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["is in invalid format"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              required(:foo).maybe(format?: /bar/)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: "bar baz" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["is in invalid format"]
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { foo: { a: 1 } } }
+
+          it "raises error" do
+            expect { result }.to raise_error TypeError
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { foo: "wat" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["is in invalid format"]
+          end
+        end
+      end
+    end
+
+    describe "with optional" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              optional(:foo).value(format?: /bar/)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: "bar baz" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["is in invalid format"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["is in invalid format"]
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { foo: { a: 1 } } }
+
+          it "raises error" do
+            expect { result }.to raise_error TypeError
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { foo: "wat" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["is in invalid format"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              optional(:foo).filled(format?: /bar/)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: "bar baz" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { foo: { a: 1 } } }
+
+          it "raises error" do
+            expect { result }.to raise_error TypeError
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { foo: "wat" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["is in invalid format"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              optional(:foo).maybe(format?: /bar/)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: "bar baz" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["is in invalid format"]
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { foo: { a: 1 } } }
+
+          it "raises error" do
+            expect { result }.to raise_error TypeError
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { foo: "wat" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["is in invalid format"]
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/validations/predicates/schema/gt_spec.rb
+++ b/spec/unit/hanami/validations/predicates/schema/gt_spec.rb
@@ -1,0 +1,555 @@
+# frozen_string_literal: true
+
+RSpec.describe "Predicates: Gt" do
+  include_context "validator result"
+
+  describe "with required" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations
+
+        validations do
+          required(:foo) { gt?(23) }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { foo: 33 } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is not successful" do
+        expect_not_successful result, ["is missing", "must be greater than 23"]
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { foo: nil } }
+
+      it "is raises error" do
+        expect { result }.to raise_error(NoMethodError)
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { foo: "" } }
+
+      it "is raises error" do
+        expect { result }.to raise_error(ArgumentError, "comparison of String with 23 failed")
+      end
+    end
+
+    describe "with invalid input type" do
+      let(:input) { { foo: [] } }
+
+      it "is raises error" do
+        expect { result }.to raise_error(NoMethodError)
+      end
+    end
+
+    describe "with equal input" do
+      let(:input) { { foo: 23 } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be greater than 23"]
+      end
+    end
+
+    describe "with less than input" do
+      let(:input) { { foo: 0 } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be greater than 23"]
+      end
+    end
+  end
+
+  describe "with optional" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations
+
+        validations do
+          optional(:foo) { gt?(23) }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { foo: 33 } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { foo: nil } }
+
+      it "is raises error" do
+        expect { result }.to raise_error(NoMethodError)
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { foo: "" } }
+
+      it "is raises error" do
+        expect { result }.to raise_error(ArgumentError, "comparison of String with 23 failed")
+      end
+    end
+
+    describe "with invalid input type" do
+      let(:input) { { foo: [] } }
+
+      it "is raises error" do
+        expect { result }.to raise_error(NoMethodError)
+      end
+    end
+
+    describe "with equal input" do
+      let(:input) { { foo: 23 } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be greater than 23"]
+      end
+    end
+
+    describe "with less than input" do
+      let(:input) { { foo: 0 } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be greater than 23"]
+      end
+    end
+  end
+
+  describe "as macro" do
+    describe "with required" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              required(:foo).value(gt?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 33 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be greater than 23"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is raises error" do
+            expect { result }.to raise_error NoMethodError
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is raises error" do
+            expect { result }.to raise_error ArgumentError, "comparison of String with 23 failed"
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { foo: [] } }
+
+          it "is raises error" do
+            expect { result }.to raise_error NoMethodError
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { foo: 23 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be greater than 23"]
+          end
+        end
+
+        describe "with less than input" do
+          let(:input) { { foo: 0 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be greater than 23"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              required(:foo).filled(gt?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 33 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be greater than 23"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be greater than 23"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be greater than 23"]
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { foo: [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be greater than 23"]
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { foo: 23 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be greater than 23"]
+          end
+        end
+
+        describe "with less than input" do
+          let(:input) { { foo: 0 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be greater than 23"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              required(:foo).maybe(gt?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 33 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be greater than 23"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is raises error" do
+            expect { result }.to raise_error(ArgumentError, "comparison of String with 23 failed")
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { foo: [] } }
+
+          it "is raises error" do
+            expect { result }.to raise_error(NoMethodError)
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { foo: 23 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be greater than 23"]
+          end
+        end
+
+        describe "with less than input" do
+          let(:input) { { foo: 0 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be greater than 23"]
+          end
+        end
+      end
+    end
+
+    describe "with optional" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              optional(:foo).value(gt?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 33 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is raises error" do
+            expect { result }.to raise_error(NoMethodError)
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is raises error" do
+            expect { result }.to raise_error(ArgumentError, "comparison of String with 23 failed")
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { foo: [] } }
+
+          it "is raises error" do
+            expect { result }.to raise_error(NoMethodError)
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { foo: 23 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be greater than 23"]
+          end
+        end
+
+        describe "with less than input" do
+          let(:input) { { foo: 0 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be greater than 23"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              optional(:foo).filled(gt?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 33 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be greater than 23"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be greater than 23"]
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { foo: [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be greater than 23"]
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { foo: 23 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be greater than 23"]
+          end
+        end
+
+        describe "with less than input" do
+          let(:input) { { foo: 0 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be greater than 23"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              optional(:foo).maybe(gt?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 33 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is raises error" do
+            expect { result }.to raise_error(ArgumentError, "comparison of String with 23 failed")
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { foo: [] } }
+
+          it "is raises error" do
+            expect { result }.to raise_error(NoMethodError)
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { foo: 23 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be greater than 23"]
+          end
+        end
+
+        describe "with less than input" do
+          let(:input) { { foo: 0 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be greater than 23"]
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/validations/predicates/schema/gteq_spec.rb
+++ b/spec/unit/hanami/validations/predicates/schema/gteq_spec.rb
@@ -1,0 +1,555 @@
+# frozen_string_literal: true
+
+RSpec.describe "Predicates: Gteq" do
+  include_context "validator result"
+
+  describe "with required" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations
+
+        validations do
+          required(:foo) { gteq?(23) }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { foo: 33 } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is not successful" do
+        expect_not_successful result, ["is missing", "must be greater than or equal to 23"]
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { foo: nil } }
+
+      it "is raises error" do
+        expect { result }.to raise_error(NoMethodError)
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { foo: "" } }
+
+      it "is raises error" do
+        expect { result }.to raise_error(ArgumentError, "comparison of String with 23 failed")
+      end
+    end
+
+    describe "with invalid input type" do
+      let(:input) { { foo: [] } }
+
+      it "is raises error" do
+        expect { result }.to raise_error(NoMethodError)
+      end
+    end
+
+    describe "with equal input" do
+      let(:input) { { foo: 23 } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with less than input" do
+      let(:input) { { foo: 0 } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be greater than or equal to 23"]
+      end
+    end
+  end
+
+  describe "with optional" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations
+
+        validations do
+          optional(:foo) { gteq?(23) }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { foo: 33 } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { foo: nil } }
+
+      it "is raises error" do
+        expect { result }.to raise_error(NoMethodError)
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { foo: "" } }
+
+      it "is raises error" do
+        expect { result }.to raise_error(ArgumentError, "comparison of String with 23 failed")
+      end
+    end
+
+    describe "with invalid input type" do
+      let(:input) { { foo: [] } }
+
+      it "is raises error" do
+        expect { result }.to raise_error(NoMethodError)
+      end
+    end
+
+    describe "with equal input" do
+      let(:input) { { foo: 23 } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with less than input" do
+      let(:input) { { foo: 0 } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be greater than or equal to 23"]
+      end
+    end
+  end
+
+  describe "as macro" do
+    describe "with required" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              required(:foo).value(gteq?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 33 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be greater than or equal to 23"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is raises error" do
+            expect { result }.to raise_error NoMethodError
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is raises error" do
+            expect { result }.to raise_error ArgumentError, "comparison of String with 23 failed"
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { foo: [] } }
+
+          it "is raises error" do
+            expect { result }.to raise_error NoMethodError
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { foo: 23 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with less than input" do
+          let(:input) { { foo: 0 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be greater than or equal to 23"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              required(:foo).filled(gteq?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 33 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be greater than or equal to 23"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be greater than or equal to 23"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be greater than or equal to 23"]
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { foo: [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be greater than or equal to 23"]
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { foo: 23 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with less than input" do
+          let(:input) { { foo: 0 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be greater than or equal to 23"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              required(:foo).maybe(gteq?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 33 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be greater than or equal to 23"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is raises error" do
+            expect { result }.to raise_error(ArgumentError, "comparison of String with 23 failed")
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { foo: [] } }
+
+          it "is raises error" do
+            expect { result }.to raise_error(NoMethodError)
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { foo: 23 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with less than input" do
+          let(:input) { { foo: 0 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be greater than or equal to 23"]
+          end
+        end
+      end
+    end
+
+    describe "with optional" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              optional(:foo).value(gteq?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 33 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is raises error" do
+            expect { result }.to raise_error(NoMethodError)
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is raises error" do
+            expect { result }.to raise_error(ArgumentError, "comparison of String with 23 failed")
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { foo: [] } }
+
+          it "is raises error" do
+            expect { result }.to raise_error(NoMethodError)
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { foo: 23 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with less than input" do
+          let(:input) { { foo: 0 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be greater than or equal to 23"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              optional(:foo).filled(gteq?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 33 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be greater than or equal to 23"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be greater than or equal to 23"]
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { foo: [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be greater than or equal to 23"]
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { foo: 23 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with less than input" do
+          let(:input) { { foo: 0 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be greater than or equal to 23"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              optional(:foo).maybe(gteq?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 33 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is raises error" do
+            expect { result }.to raise_error(ArgumentError, "comparison of String with 23 failed")
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { foo: [] } }
+
+          it "is raises error" do
+            expect { result }.to raise_error(NoMethodError)
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { foo: 23 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with less than input" do
+          let(:input) { { foo: 0 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be greater than or equal to 23"]
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/validations/predicates/schema/included_in_spec.rb
+++ b/spec/unit/hanami/validations/predicates/schema/included_in_spec.rb
@@ -1,0 +1,491 @@
+# frozen_string_literal: true
+
+RSpec.describe "Predicates: Included In" do
+  include_context "validator result"
+
+  describe "with required" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations
+
+        validations do
+          required(:foo) { included_in?([1, 3, 5]) }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { foo: 3 } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is not successful" do
+        expect_not_successful result, ["is missing", "must be one of: 1, 3, 5"]
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { foo: nil } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be one of: 1, 3, 5"]
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { foo: "" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be one of: 1, 3, 5"]
+      end
+    end
+
+    describe "with invalid type" do
+      let(:input) { { foo: { a: 1 } } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be one of: 1, 3, 5"]
+      end
+    end
+
+    describe "with invalid input" do
+      let(:input) { { foo: 4 } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be one of: 1, 3, 5"]
+      end
+    end
+  end
+
+  describe "with optional" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations
+
+        validations do
+          optional(:foo) { included_in?([1, 3, 5]) }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { foo: 3 } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { foo: nil } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be one of: 1, 3, 5"]
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { foo: "" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be one of: 1, 3, 5"]
+      end
+    end
+
+    describe "with invalid type" do
+      let(:input) { { foo: { a: 1 } } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be one of: 1, 3, 5"]
+      end
+    end
+
+    describe "with invalid input" do
+      let(:input) { { foo: 4 } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be one of: 1, 3, 5"]
+      end
+    end
+  end
+
+  describe "as macro" do
+    describe "with required" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              required(:foo).value(included_in?: [1, 3, 5])
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 3 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { foo: { a: 1 } } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { foo: 4 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be one of: 1, 3, 5"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              required(:foo).filled(included_in?: [1, 3, 5])
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 3 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { foo: { a: 1 } } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { foo: 4 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be one of: 1, 3, 5"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              required(:foo).maybe(included_in?: [1, 3, 5])
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 3 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { foo: { a: 1 } } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { foo: 4 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be one of: 1, 3, 5"]
+          end
+        end
+      end
+    end
+
+    describe "with optional" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              optional(:foo).value(included_in?: [1, 3, 5])
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 3 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { foo: { a: 1 } } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { foo: 4 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be one of: 1, 3, 5"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              optional(:foo).filled(included_in?: [1, 3, 5])
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 3 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { foo: { a: 1 } } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { foo: 4 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be one of: 1, 3, 5"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              optional(:foo).maybe(included_in?: [1, 3, 5])
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 3 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { foo: { a: 1 } } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be one of: 1, 3, 5"]
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { foo: 4 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be one of: 1, 3, 5"]
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/validations/predicates/schema/lt_spec.rb
+++ b/spec/unit/hanami/validations/predicates/schema/lt_spec.rb
@@ -1,0 +1,555 @@
+# frozen_string_literal: true
+
+RSpec.describe "Predicates: Lt" do
+  include_context "validator result"
+
+  describe "with required" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations
+
+        validations do
+          required(:foo) { lt?(23) }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { foo: 1 } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is not successful" do
+        expect_not_successful result, ["is missing", "must be less than 23"]
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { foo: nil } }
+
+      it "is raises error" do
+        expect { result }.to raise_error(NoMethodError)
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { foo: "" } }
+
+      it "is raises error" do
+        expect { result }.to raise_error(ArgumentError, "comparison of String with 23 failed")
+      end
+    end
+
+    describe "with invalid input type" do
+      let(:input) { { foo: [] } }
+
+      it "is raises error" do
+        expect { result }.to raise_error(NoMethodError)
+      end
+    end
+
+    describe "with equal input" do
+      let(:input) { { foo: 23 } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be less than 23"]
+      end
+    end
+
+    describe "with greater than input" do
+      let(:input) { { foo: 99 } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be less than 23"]
+      end
+    end
+  end
+
+  describe "with optional" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations
+
+        validations do
+          optional(:foo) { lt?(23) }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { foo: 1 } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { foo: nil } }
+
+      it "is raises error" do
+        expect { result }.to raise_error(NoMethodError)
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { foo: "" } }
+
+      it "is raises error" do
+        expect { result }.to raise_error(ArgumentError, "comparison of String with 23 failed")
+      end
+    end
+
+    describe "with invalid input type" do
+      let(:input) { { foo: [] } }
+
+      it "is raises error" do
+        expect { result }.to raise_error(NoMethodError)
+      end
+    end
+
+    describe "with equal input" do
+      let(:input) { { foo: 23 } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be less than 23"]
+      end
+    end
+
+    describe "with greater than input" do
+      let(:input) { { foo: 99 } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be less than 23"]
+      end
+    end
+  end
+
+  describe "as macro" do
+    describe "with required" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              required(:foo).value(lt?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 1 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be less than 23"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is raises error" do
+            expect { result }.to raise_error(NoMethodError)
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is raises error" do
+            expect { result }.to raise_error(ArgumentError, "comparison of String with 23 failed")
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { foo: [] } }
+
+          it "is raises error" do
+            expect { result }.to raise_error(NoMethodError)
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { foo: 23 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be less than 23"]
+          end
+        end
+
+        describe "with greater than input" do
+          let(:input) { { foo: 99 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be less than 23"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              required(:foo).filled(lt?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 1 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be less than 23"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be less than 23"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be less than 23"]
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { foo: [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be less than 23"]
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { foo: 23 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be less than 23"]
+          end
+        end
+
+        describe "with greater than input" do
+          let(:input) { { foo: 99 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be less than 23"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              required(:foo).maybe(lt?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 1 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be less than 23"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is raises error" do
+            expect { result }.to raise_error(ArgumentError, "comparison of String with 23 failed")
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { foo: [] } }
+
+          it "is raises error" do
+            expect { result }.to raise_error(NoMethodError)
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { foo: 23 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be less than 23"]
+          end
+        end
+
+        describe "with greater than input" do
+          let(:input) { { foo: 99 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be less than 23"]
+          end
+        end
+      end
+    end
+
+    describe "with optional" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              optional(:foo).value(lt?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 1 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "raises error" do
+            expect { result }.to raise_error(NoMethodError)
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "raises error" do
+            expect { result }.to raise_error(ArgumentError, "comparison of String with 23 failed")
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { foo: [] } }
+
+          it "raises error" do
+            expect { result }.to raise_error(NoMethodError)
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { foo: 23 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be less than 23"]
+          end
+        end
+
+        describe "with greater than input" do
+          let(:input) { { foo: 99 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be less than 23"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              optional(:foo).filled(lt?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 1 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be less than 23"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be less than 23"]
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { foo: [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be less than 23"]
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { foo: 23 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be less than 23"]
+          end
+        end
+
+        describe "with greater than input" do
+          let(:input) { { foo: 99 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be less than 23"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              optional(:foo).maybe(lt?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 1 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is raises error" do
+            expect { result }.to raise_error(ArgumentError, "comparison of String with 23 failed")
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { foo: [] } }
+
+          it "is raises error" do
+            expect { result }.to raise_error(NoMethodError)
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { foo: 23 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be less than 23"]
+          end
+        end
+
+        describe "with greater than input" do
+          let(:input) { { foo: 99 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be less than 23"]
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/validations/predicates/schema/lteq_spec.rb
+++ b/spec/unit/hanami/validations/predicates/schema/lteq_spec.rb
@@ -1,0 +1,555 @@
+# frozen_string_literal: true
+
+RSpec.describe "Predicates: Lteq" do
+  include_context "validator result"
+
+  describe "with required" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations
+
+        validations do
+          required(:foo) { lteq?(23) }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { foo: 1 } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is not successful" do
+        expect_not_successful result, ["is missing", "must be less than or equal to 23"]
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { foo: nil } }
+
+      it "is raises error" do
+        expect { result }.to raise_error(NoMethodError)
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { foo: "" } }
+
+      it "is raises error" do
+        expect { result }.to raise_error(ArgumentError, "comparison of String with 23 failed")
+      end
+    end
+
+    describe "with invalid input type" do
+      let(:input) { { foo: [] } }
+
+      it "is raises error" do
+        expect { result }.to raise_error(NoMethodError)
+      end
+    end
+
+    describe "with equal input" do
+      let(:input) { { foo: 23 } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with greater than input" do
+      let(:input) { { foo: 99 } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be less than or equal to 23"]
+      end
+    end
+  end
+
+  describe "with optional" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations
+
+        validations do
+          optional(:foo) { lteq?(23) }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { foo: 1 } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { foo: nil } }
+
+      it "is raises error" do
+        expect { result }.to raise_error(NoMethodError)
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { foo: "" } }
+
+      it "is raises error" do
+        expect { result }.to raise_error(ArgumentError, "comparison of String with 23 failed")
+      end
+    end
+
+    describe "with invalid input type" do
+      let(:input) { { foo: [] } }
+
+      it "is raises error" do
+        expect { result }.to raise_error(NoMethodError)
+      end
+    end
+
+    describe "with equal input" do
+      let(:input) { { foo: 23 } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with greater than input" do
+      let(:input) { { foo: 99 } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be less than or equal to 23"]
+      end
+    end
+  end
+
+  describe "as macro" do
+    describe "with required" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              required(:foo).value(lteq?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 1 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be less than or equal to 23"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is raises error" do
+            expect { result }.to raise_error(NoMethodError)
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is raises error" do
+            expect { result }.to raise_error(ArgumentError, "comparison of String with 23 failed")
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { foo: [] } }
+
+          it "is raises error" do
+            expect { result }.to raise_error(NoMethodError)
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { foo: 23 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with greater than input" do
+          let(:input) { { foo: 99 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be less than or equal to 23"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              required(:foo).filled(lteq?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 1 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be less than or equal to 23"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be less than or equal to 23"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be less than or equal to 23"]
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { foo: [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be less than or equal to 23"]
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { foo: 23 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with greater than input" do
+          let(:input) { { foo: 99 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be less than or equal to 23"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              required(:foo).maybe(lteq?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 1 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be less than or equal to 23"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is raises error" do
+            expect { result }.to raise_error(ArgumentError, "comparison of String with 23 failed")
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { foo: [] } }
+
+          it "is raises error" do
+            expect { result }.to raise_error(NoMethodError)
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { foo: 23 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with greater than input" do
+          let(:input) { { foo: 99 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be less than or equal to 23"]
+          end
+        end
+      end
+    end
+
+    describe "with optional" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              optional(:foo).value(lteq?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 1 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "raises error" do
+            expect { result }.to raise_error(NoMethodError)
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "raises error" do
+            expect { result }.to raise_error(ArgumentError, "comparison of String with 23 failed")
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { foo: [] } }
+
+          it "raises error" do
+            expect { result }.to raise_error(NoMethodError)
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { foo: 23 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with greater than input" do
+          let(:input) { { foo: 99 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be less than or equal to 23"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              optional(:foo).filled(lteq?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 1 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be less than or equal to 23"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be less than or equal to 23"]
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { foo: [] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be less than or equal to 23"]
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { foo: 23 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with greater than input" do
+          let(:input) { { foo: 99 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be less than or equal to 23"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              optional(:foo).maybe(lteq?: 23)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 1 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is raises error" do
+            expect { result }.to raise_error(ArgumentError, "comparison of String with 23 failed")
+          end
+        end
+
+        describe "with invalid input type" do
+          let(:input) { { foo: [] } }
+
+          it "is raises error" do
+            expect { result }.to raise_error(NoMethodError)
+          end
+        end
+
+        describe "with equal input" do
+          let(:input) { { foo: 23 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with greater than input" do
+          let(:input) { { foo: 99 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be less than or equal to 23"]
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/validations/predicates/schema/max_size_spec.rb
+++ b/spec/unit/hanami/validations/predicates/schema/max_size_spec.rb
@@ -1,0 +1,427 @@
+# frozen_string_literal: true
+
+RSpec.describe "Predicates: Max Size" do
+  include_context "validator result"
+
+  describe "with required" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations
+
+        validations do
+          required(:foo) { max_size?(3) }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { foo: [1, 2, 3] } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is not successful" do
+        expect_not_successful result, ["is missing", "size cannot be greater than 3"]
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { foo: nil } }
+
+      it "is raises error" do
+        expect { result }.to raise_error(NoMethodError)
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { foo: "" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with invalid input" do
+      let(:input) { { foo: { a: 1, b: 2, c: 3, d: 4 } } }
+
+      it "is not successful" do
+        expect_not_successful result, ["size cannot be greater than 3"]
+      end
+    end
+  end
+
+  describe "with optional" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations
+
+        validations do
+          optional(:foo) { max_size?(3) }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { foo: [1, 2, 3] } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { foo: nil } }
+
+      it "is raises error" do
+        expect { result }.to raise_error(NoMethodError)
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { foo: "" } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with invalid input" do
+      let(:input) { { foo: { a: 1, b: 2, c: 3, d: 4 } } }
+
+      it "is not successful" do
+        expect_not_successful result, ["size cannot be greater than 3"]
+      end
+    end
+  end
+
+  describe "as macro" do
+    describe "with required" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              required(:foo).value(max_size?: 3)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: [1, 2, 3] } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "size cannot be greater than 3"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is not successful" do
+            expect { result }.to raise_error(NoMethodError)
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { foo: { a: 1, b: 2, c: 3, d: 4 } } }
+
+          it "is not successful" do
+            expect_not_successful result, ["size cannot be greater than 3"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              required(:foo).filled(max_size?: 3)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: [1, 2, 3] } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "size cannot be greater than 3"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "size cannot be greater than 3"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "size cannot be greater than 3"]
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { foo: { a: 1, b: 2, c: 3, d: 4 } } }
+
+          it "is not successful" do
+            expect_not_successful result, ["size cannot be greater than 3"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              required(:foo).maybe(max_size?: 3)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: [1, 2, 3] } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "size cannot be greater than 3"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { foo: { a: 1, b: 2, c: 3, d: 4 } } }
+
+          it "is not successful" do
+            expect_not_successful result, ["size cannot be greater than 3"]
+          end
+        end
+      end
+    end
+
+    describe "with optional" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              optional(:foo).value(max_size?: 3)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: [1, 2, 3] } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is raises error" do
+            expect { result }.to raise_error(NoMethodError)
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { foo: { a: 1, b: 2, c: 3, d: 4 } } }
+
+          it "is not successful" do
+            expect_not_successful result, ["size cannot be greater than 3"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              optional(:foo).filled(max_size?: 3)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: [1, 2, 3] } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "size cannot be greater than 3"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "size cannot be greater than 3"]
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { foo: { a: 1, b: 2, c: 3, d: 4 } } }
+
+          it "is not successful" do
+            expect_not_successful result, ["size cannot be greater than 3"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              optional(:foo).maybe(max_size?: 3)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: [1, 2, 3] } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { foo: { a: 1, b: 2, c: 3, d: 4 } } }
+
+          it "is not successful" do
+            expect_not_successful result, ["size cannot be greater than 3"]
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/validations/predicates/schema/min_size_spec.rb
+++ b/spec/unit/hanami/validations/predicates/schema/min_size_spec.rb
@@ -1,0 +1,427 @@
+# frozen_string_literal: true
+
+RSpec.describe "Predicates: Min Size" do
+  include_context "validator result"
+
+  describe "with required" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations
+
+        validations do
+          required(:foo) { min_size?(3) }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { foo: [1, 2, 3] } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is not successful" do
+        expect_not_successful result, ["is missing", "size cannot be less than 3"]
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { foo: nil } }
+
+      it "is raises error" do
+        expect { result }.to raise_error(NoMethodError)
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { foo: "" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["size cannot be less than 3"]
+      end
+    end
+
+    describe "with invalid input" do
+      let(:input) { { foo: { a: 1, b: 2 } } }
+
+      it "is not successful" do
+        expect_not_successful result, ["size cannot be less than 3"]
+      end
+    end
+  end
+
+  describe "with optional" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations
+
+        validations do
+          optional(:foo) { min_size?(3) }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { foo: [1, 2, 3] } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { foo: nil } }
+
+      it "is raises error" do
+        expect { result }.to raise_error(NoMethodError)
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { foo: "" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["size cannot be less than 3"]
+      end
+    end
+
+    describe "with invalid input" do
+      let(:input) { { foo: { a: 1, b: 2 } } }
+
+      it "is not successful" do
+        expect_not_successful result, ["size cannot be less than 3"]
+      end
+    end
+  end
+
+  describe "as macro" do
+    describe "with required" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              required(:foo).value(min_size?: 3)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: [1, 2, 3] } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "size cannot be less than 3"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is raises error" do
+            expect { result }.to raise_error(NoMethodError)
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["size cannot be less than 3"]
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { foo: { a: 1, b: 2 } } }
+
+          it "is not successful" do
+            expect_not_successful result, ["size cannot be less than 3"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              required(:foo).filled(min_size?: 3)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: [1, 2, 3] } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "size cannot be less than 3"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "size cannot be less than 3"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "size cannot be less than 3"]
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { foo: { a: 1, b: 2 } } }
+
+          it "is not successful" do
+            expect_not_successful result, ["size cannot be less than 3"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              required(:foo).maybe(min_size?: 3)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: [1, 2, 3] } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "size cannot be less than 3"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["size cannot be less than 3"]
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { foo: { a: 1, b: 2 } } }
+
+          it "is not successful" do
+            expect_not_successful result, ["size cannot be less than 3"]
+          end
+        end
+      end
+    end
+
+    describe "with optional" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              optional(:foo).value(min_size?: 3)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: [1, 2, 3] } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is raises error" do
+            expect { result }.to raise_error(NoMethodError)
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["size cannot be less than 3"]
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { foo: { a: 1, b: 2 } } }
+
+          it "is not successful" do
+            expect_not_successful result, ["size cannot be less than 3"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              optional(:foo).filled(min_size?: 3)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: [1, 2, 3] } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "size cannot be less than 3"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "size cannot be less than 3"]
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { foo: { a: 1, b: 2 } } }
+
+          it "is not successful" do
+            expect_not_successful result, ["size cannot be less than 3"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              optional(:foo).maybe(min_size?: 3)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: [1, 2, 3] } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["size cannot be less than 3"]
+          end
+        end
+
+        describe "with invalid input" do
+          let(:input) { { foo: { a: 1, b: 2 } } }
+
+          it "is not successful" do
+            expect_not_successful result, ["size cannot be less than 3"]
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/validations/predicates/schema/none_spec.rb
+++ b/spec/unit/hanami/validations/predicates/schema/none_spec.rb
@@ -1,0 +1,295 @@
+# frozen_string_literal: true
+
+RSpec.describe "Predicates: None" do
+  include_context "validator result"
+
+  describe "with required" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations
+
+        validations do
+          required(:foo) { none? }
+        end
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is not successful" do
+        expect_not_successful result, ["is missing"]
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { foo: nil } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { foo: "" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["cannot be defined"]
+      end
+    end
+
+    describe "with other input" do
+      let(:input) { { foo: 23 } }
+
+      it "is not successful" do
+        expect_not_successful result, ["cannot be defined"]
+      end
+    end
+  end
+
+  describe "with optional" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations
+
+        validations do
+          optional(:foo) { none? }
+        end
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { foo: nil } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { foo: "" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["cannot be defined"]
+      end
+    end
+
+    describe "with other input" do
+      let(:input) { { foo: 23 } }
+
+      it "is not successful" do
+        expect_not_successful result, ["cannot be defined"]
+      end
+    end
+  end
+
+  describe "as macro" do
+    describe "with required" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              required(:foo).value(:none?)
+            end
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["cannot be defined"]
+          end
+        end
+
+        describe "with other input" do
+          let(:input) { { foo: 23 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["cannot be defined"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              required(:foo).filled(:none?)
+            end
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+
+        describe "with other input" do
+          let(:input) { { foo: 23 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["cannot be defined"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        # it doesn't make sense to ask for a maybe key and at the same time assert it's none
+        #
+        # Example:
+        #
+        #   validations do
+        #     required(:foo).maybe(:empty?)
+        #   end
+      end
+    end
+
+    describe "with optional" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              optional(:foo).value(:none?)
+            end
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["cannot be defined"]
+          end
+        end
+
+        describe "with other input" do
+          let(:input) { { foo: 23 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["cannot be defined"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              optional(:foo).filled(:none?)
+            end
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled"]
+          end
+        end
+
+        describe "with other input" do
+          let(:input) { { foo: 23 } }
+
+          it "is not successful" do
+            expect_not_successful result, ["cannot be defined"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        # it doesn't make sense to ask for a maybe key and at the same time assert it's none
+        #
+        # Example:
+        #
+        #   validations do
+        #     optional(:foo).maybe(:none?)
+        #   end
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/validations/predicates/schema/size/fixed_spec.rb
+++ b/spec/unit/hanami/validations/predicates/schema/size/fixed_spec.rb
@@ -1,0 +1,429 @@
+# frozen_string_literal: true
+
+RSpec.describe "Predicates: Size" do
+  include_context "validator result"
+
+  describe "Fixed (integer)" do
+    describe "with required" do
+      before do
+        @validator = Class.new do
+          include Hanami::Validations
+
+          validations do
+            required(:foo) { size?(3) }
+          end
+        end
+      end
+
+      describe "with valid input" do
+        let(:input) { { foo: [1, 2, 3] } }
+
+        it "is successful" do
+          expect_successful result
+        end
+      end
+
+      describe "with missing input" do
+        let(:input) { {} }
+
+        it "is not successful" do
+          expect_not_successful result, ["is missing", "size must be 3"]
+        end
+      end
+
+      describe "with nil input" do
+        let(:input) { { foo: nil } }
+
+        it "is raises error" do
+          expect { result }.to raise_error(NoMethodError)
+        end
+      end
+
+      describe "with blank input" do
+        let(:input) { { foo: "" } }
+
+        it "is not successful" do
+          expect_not_successful result, ["length must be 3"]
+        end
+      end
+
+      describe "with invalid input" do
+        let(:input) { { foo: { a: 1, b: 2, c: 3, d: 4 } } }
+
+        it "is not successful" do
+          expect_not_successful result, ["size must be 3"]
+        end
+      end
+    end
+
+    describe "with optional" do
+      before do
+        @validator = Class.new do
+          include Hanami::Validations
+
+          validations do
+            optional(:foo) { size?(3) }
+          end
+        end
+      end
+
+      describe "with valid input" do
+        let(:input) { { foo: [1, 2, 3] } }
+
+        it "is successful" do
+          expect_successful result
+        end
+      end
+
+      describe "with missing input" do
+        let(:input) { {} }
+
+        it "is successful" do
+          expect_successful result
+        end
+      end
+
+      describe "with nil input" do
+        let(:input) { { foo: nil } }
+
+        it "is raises error" do
+          expect { result }.to raise_error(NoMethodError)
+        end
+      end
+
+      describe "with blank input" do
+        let(:input) { { foo: "" } }
+
+        it "is not successful" do
+          expect_not_successful result, ["length must be 3"]
+        end
+      end
+
+      describe "with invalid input" do
+        let(:input) { { foo: { a: 1, b: 2, c: 3, d: 4 } } }
+
+        it "is not successful" do
+          expect_not_successful result, ["size must be 3"]
+        end
+      end
+    end
+
+    describe "as macro" do
+      describe "with required" do
+        describe "with value" do
+          before do
+            @validator = Class.new do
+              include Hanami::Validations
+
+              validations do
+                required(:foo).value(size?: 3)
+              end
+            end
+          end
+
+          describe "with valid input" do
+            let(:input) { { foo: [1, 2, 3] } }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with missing input" do
+            let(:input) { {} }
+
+            it "is not successful" do
+              expect_not_successful result, ["is missing", "size must be 3"]
+            end
+          end
+
+          describe "with nil input" do
+            let(:input) { { foo: nil } }
+
+            it "is raises error" do
+              expect { result }.to raise_error(NoMethodError)
+            end
+          end
+
+          describe "with blank input" do
+            let(:input) { { foo: "" } }
+
+            it "is not successful" do
+              expect_not_successful result, ["length must be 3"]
+            end
+          end
+
+          describe "with invalid input" do
+            let(:input) { { foo: { a: 1, b: 2, c: 3, d: 4 } } }
+
+            it "is not successful" do
+              expect_not_successful result, ["size must be 3"]
+            end
+          end
+        end
+
+        describe "with filled" do
+          before do
+            @validator = Class.new do
+              include Hanami::Validations
+
+              validations do
+                required(:foo).filled(size?: 3)
+              end
+            end
+          end
+
+          describe "with valid input" do
+            let(:input) { { foo: [1, 2, 3] } }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with missing input" do
+            let(:input) { {} }
+
+            it "is not successful" do
+              expect_not_successful result, ["is missing", "size must be 3"]
+            end
+          end
+
+          describe "with nil input" do
+            let(:input) { { foo: nil } }
+
+            it "is not successful" do
+              expect_not_successful result, ["must be filled", "size must be 3"]
+            end
+          end
+
+          describe "with blank input" do
+            let(:input) { { foo: "" } }
+
+            it "is not successful" do
+              expect_not_successful result, ["must be filled", "length must be 3"]
+            end
+          end
+
+          describe "with invalid input" do
+            let(:input) { { foo: { a: 1, b: 2, c: 3, d: 4 } } }
+
+            it "is not successful" do
+              expect_not_successful result, ["size must be 3"]
+            end
+          end
+        end
+
+        describe "with maybe" do
+          before do
+            @validator = Class.new do
+              include Hanami::Validations
+
+              validations do
+                required(:foo).maybe(size?: 3)
+              end
+            end
+          end
+
+          describe "with valid input" do
+            let(:input) { { foo: [1, 2, 3] } }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with missing input" do
+            let(:input) { {} }
+
+            it "is not successful" do
+              expect_not_successful result, ["is missing", "size must be 3"]
+            end
+          end
+
+          describe "with nil input" do
+            let(:input) { { foo: nil } }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with blank input" do
+            let(:input) { { foo: "" } }
+
+            it "is not successful" do
+              expect_not_successful result, ["length must be 3"]
+            end
+          end
+
+          describe "with invalid input" do
+            let(:input) { { foo: { a: 1, b: 2, c: 3, d: 4 } } }
+
+            it "is not successful" do
+              expect_not_successful result, ["size must be 3"]
+            end
+          end
+        end
+      end
+
+      describe "with optional" do
+        describe "with value" do
+          before do
+            @validator = Class.new do
+              include Hanami::Validations
+
+              validations do
+                optional(:foo).value(size?: 3)
+              end
+            end
+          end
+
+          describe "with valid input" do
+            let(:input) { { foo: [1, 2, 3] } }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with missing input" do
+            let(:input) { {} }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with nil input" do
+            let(:input) { { foo: nil } }
+
+            it "is raises error" do
+              expect { result }.to raise_error(NoMethodError)
+            end
+          end
+
+          describe "with blank input" do
+            let(:input) { { foo: "" } }
+
+            it "is not successful" do
+              expect_not_successful result, ["length must be 3"]
+            end
+          end
+
+          describe "with invalid input" do
+            let(:input) { { foo: { a: 1, b: 2, c: 3, d: 4 } } }
+
+            it "is not successful" do
+              expect_not_successful result, ["size must be 3"]
+            end
+          end
+        end
+
+        describe "with filled" do
+          before do
+            @validator = Class.new do
+              include Hanami::Validations
+
+              validations do
+                optional(:foo).filled(size?: 3)
+              end
+            end
+          end
+
+          describe "with valid input" do
+            let(:input) { { foo: [1, 2, 3] } }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with missing input" do
+            let(:input) { {} }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with nil input" do
+            let(:input) { { foo: nil } }
+
+            it "is not successful" do
+              expect_not_successful result, ["must be filled", "size must be 3"]
+            end
+          end
+
+          describe "with blank input" do
+            let(:input) { { foo: "" } }
+
+            it "is not successful" do
+              expect_not_successful result, ["must be filled", "length must be 3"]
+            end
+          end
+
+          describe "with invalid input" do
+            let(:input) { { foo: { a: 1, b: 2, c: 3, d: 4 } } }
+
+            it "is not successful" do
+              expect_not_successful result, ["size must be 3"]
+            end
+          end
+        end
+
+        describe "with maybe" do
+          before do
+            @validator = Class.new do
+              include Hanami::Validations
+
+              validations do
+                optional(:foo).maybe(size?: 3)
+              end
+            end
+          end
+
+          describe "with valid input" do
+            let(:input) { { foo: [1, 2, 3] } }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with missing input" do
+            let(:input) { {} }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with nil input" do
+            let(:input) { { foo: nil } }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with blank input" do
+            let(:input) { { foo: "" } }
+
+            it "is not successful" do
+              expect_not_successful result, ["length must be 3"]
+            end
+          end
+
+          describe "with invalid input" do
+            let(:input) { { foo: { a: 1, b: 2, c: 3, d: 4 } } }
+
+            it "is not successful" do
+              expect_not_successful result, ["size must be 3"]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/validations/predicates/schema/size/range_spec.rb
+++ b/spec/unit/hanami/validations/predicates/schema/size/range_spec.rb
@@ -1,0 +1,429 @@
+# frozen_string_literal: true
+
+RSpec.describe "Predicates: Size" do
+  include_context "validator result"
+
+  describe "Range" do
+    describe "with required" do
+      before do
+        @validator = Class.new do
+          include Hanami::Validations
+
+          validations do
+            required(:foo) { size?(2..3) }
+          end
+        end
+      end
+
+      describe "with valid input" do
+        let(:input) { { foo: [1, 2, 3] } }
+
+        it "is successful" do
+          expect_successful result
+        end
+      end
+
+      describe "with missing input" do
+        let(:input) { {} }
+
+        it "is not successful" do
+          expect_not_successful result, ["is missing", "size must be within 2 - 3"]
+        end
+      end
+
+      describe "with nil input" do
+        let(:input) { { foo: nil } }
+
+        it "is raises error" do
+          expect { result }.to raise_error(NoMethodError)
+        end
+      end
+
+      describe "with blank input" do
+        let(:input) { { foo: "" } }
+
+        it "is not successful" do
+          expect_not_successful result, ["length must be within 2 - 3"]
+        end
+      end
+
+      describe "with invalid input" do
+        let(:input) { { foo: { a: 1, b: 2, c: 3, d: 4 } } }
+
+        it "is not successful" do
+          expect_not_successful result, ["size must be within 2 - 3"]
+        end
+      end
+    end
+
+    describe "with optional" do
+      before do
+        @validator = Class.new do
+          include Hanami::Validations
+
+          validations do
+            optional(:foo) { size?(2..3) }
+          end
+        end
+      end
+
+      describe "with valid input" do
+        let(:input) { { foo: [1, 2, 3] } }
+
+        it "is successful" do
+          expect_successful result
+        end
+      end
+
+      describe "with missing input" do
+        let(:input) { {} }
+
+        it "is successful" do
+          expect_successful result
+        end
+      end
+
+      describe "with nil input" do
+        let(:input) { { foo: nil } }
+
+        it "is raises error" do
+          expect { result }.to raise_error(NoMethodError)
+        end
+      end
+
+      describe "with blank input" do
+        let(:input) { { foo: "" } }
+
+        it "is not successful" do
+          expect_not_successful result, ["length must be within 2 - 3"]
+        end
+      end
+
+      describe "with invalid input" do
+        let(:input) { { foo: { a: 1, b: 2, c: 3, d: 4 } } }
+
+        it "is not successful" do
+          expect_not_successful result, ["size must be within 2 - 3"]
+        end
+      end
+    end
+
+    describe "as macro" do
+      describe "with required" do
+        describe "with value" do
+          before do
+            @validator = Class.new do
+              include Hanami::Validations
+
+              validations do
+                required(:foo).value(size?: 2..3)
+              end
+            end
+          end
+
+          describe "with valid input" do
+            let(:input) { { foo: [1, 2, 3] } }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with missing input" do
+            let(:input) { {} }
+
+            it "is not successful" do
+              expect_not_successful result, ["is missing", "size must be within 2 - 3"]
+            end
+          end
+
+          describe "with nil input" do
+            let(:input) { { foo: nil } }
+
+            it "is raises error" do
+              expect { result }.to raise_error(NoMethodError)
+            end
+          end
+
+          describe "with blank input" do
+            let(:input) { { foo: "" } }
+
+            it "is not successful" do
+              expect_not_successful result, ["length must be within 2 - 3"]
+            end
+          end
+
+          describe "with invalid input" do
+            let(:input) { { foo: { a: 1, b: 2, c: 3, d: 4 } } }
+
+            it "is not successful" do
+              expect_not_successful result, ["size must be within 2 - 3"]
+            end
+          end
+        end
+
+        describe "with filled" do
+          before do
+            @validator = Class.new do
+              include Hanami::Validations
+
+              validations do
+                required(:foo).filled(size?: 2..3)
+              end
+            end
+          end
+
+          describe "with valid input" do
+            let(:input) { { foo: [1, 2, 3] } }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with missing input" do
+            let(:input) { {} }
+
+            it "is not successful" do
+              expect_not_successful result, ["is missing", "size must be within 2 - 3"]
+            end
+          end
+
+          describe "with nil input" do
+            let(:input) { { foo: nil } }
+
+            it "is not successful" do
+              expect_not_successful result, ["must be filled", "size must be within 2 - 3"]
+            end
+          end
+
+          describe "with blank input" do
+            let(:input) { { foo: "" } }
+
+            it "is not successful" do
+              expect_not_successful result, ["must be filled", "length must be within 2 - 3"]
+            end
+          end
+
+          describe "with invalid input" do
+            let(:input) { { foo: { a: 1, b: 2, c: 3, d: 4 } } }
+
+            it "is not successful" do
+              expect_not_successful result, ["size must be within 2 - 3"]
+            end
+          end
+        end
+
+        describe "with maybe" do
+          before do
+            @validator = Class.new do
+              include Hanami::Validations
+
+              validations do
+                required(:foo).maybe(size?: 2..3)
+              end
+            end
+          end
+
+          describe "with valid input" do
+            let(:input) { { foo: [1, 2, 3] } }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with missing input" do
+            let(:input) { {} }
+
+            it "is not successful" do
+              expect_not_successful result, ["is missing", "size must be within 2 - 3"]
+            end
+          end
+
+          describe "with nil input" do
+            let(:input) { { foo: nil } }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with blank input" do
+            let(:input) { { foo: "" } }
+
+            it "is not successful" do
+              expect_not_successful result, ["length must be within 2 - 3"]
+            end
+          end
+
+          describe "with invalid input" do
+            let(:input) { { foo: { a: 1, b: 2, c: 3, d: 4 } } }
+
+            it "is not successful" do
+              expect_not_successful result, ["size must be within 2 - 3"]
+            end
+          end
+        end
+      end
+
+      describe "with optional" do
+        describe "with value" do
+          before do
+            @validator = Class.new do
+              include Hanami::Validations
+
+              validations do
+                optional(:foo).value(size?: 2..3)
+              end
+            end
+          end
+
+          describe "with valid input" do
+            let(:input) { { foo: [1, 2, 3] } }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with missing input" do
+            let(:input) { {} }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with nil input" do
+            let(:input) { { foo: nil } }
+
+            it "is raises error" do
+              expect { result }.to raise_error(NoMethodError)
+            end
+          end
+
+          describe "with blank input" do
+            let(:input) { { foo: "" } }
+
+            it "is not successful" do
+              expect_not_successful result, ["length must be within 2 - 3"]
+            end
+          end
+
+          describe "with invalid input" do
+            let(:input) { { foo: { a: 1, b: 2, c: 3, d: 4 } } }
+
+            it "is not successful" do
+              expect_not_successful result, ["size must be within 2 - 3"]
+            end
+          end
+        end
+
+        describe "with filled" do
+          before do
+            @validator = Class.new do
+              include Hanami::Validations
+
+              validations do
+                optional(:foo).filled(size?: 2..3)
+              end
+            end
+          end
+
+          describe "with valid input" do
+            let(:input) { { foo: [1, 2, 3] } }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with missing input" do
+            let(:input) { {} }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with nil input" do
+            let(:input) { { foo: nil } }
+
+            it "is not successful" do
+              expect_not_successful result, ["must be filled", "size must be within 2 - 3"]
+            end
+          end
+
+          describe "with blank input" do
+            let(:input) { { foo: "" } }
+
+            it "is not successful" do
+              expect_not_successful result, ["must be filled", "length must be within 2 - 3"]
+            end
+          end
+
+          describe "with invalid input" do
+            let(:input) { { foo: { a: 1, b: 2, c: 3, d: 4 } } }
+
+            it "is not successful" do
+              expect_not_successful result, ["size must be within 2 - 3"]
+            end
+          end
+        end
+
+        describe "with maybe" do
+          before do
+            @validator = Class.new do
+              include Hanami::Validations
+
+              validations do
+                optional(:foo).maybe(size?: 2..3)
+              end
+            end
+          end
+
+          describe "with valid input" do
+            let(:input) { { foo: [1, 2, 3] } }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with missing input" do
+            let(:input) { {} }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with nil input" do
+            let(:input) { { foo: nil } }
+
+            it "is successful" do
+              expect_successful result
+            end
+          end
+
+          describe "with blank input" do
+            let(:input) { { foo: "" } }
+
+            it "is not successful" do
+              expect_not_successful result, ["length must be within 2 - 3"]
+            end
+          end
+
+          describe "with invalid input" do
+            let(:input) { { foo: { a: 1, b: 2, c: 3, d: 4 } } }
+
+            it "is not successful" do
+              expect_not_successful result, ["size must be within 2 - 3"]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/validations/predicates/schema/type_spec.rb
+++ b/spec/unit/hanami/validations/predicates/schema/type_spec.rb
@@ -1,0 +1,427 @@
+# frozen_string_literal: true
+
+RSpec.describe "Predicates: Type" do
+  include_context "validator result"
+
+  describe "with required" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations
+
+        validations do
+          required(:foo) { type?(Integer) }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { foo: 23 } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is not successful" do
+        expect_not_successful result, ["is missing", "must be Integer"]
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { foo: nil } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be Integer"]
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { foo: "" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be Integer"]
+      end
+    end
+
+    describe "with invalid type" do
+      let(:input) { { foo: [:x] } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be Integer"]
+      end
+    end
+  end
+
+  describe "with optional" do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations
+
+        validations do
+          optional(:foo) { type?(Integer) }
+        end
+      end
+    end
+
+    describe "with valid input" do
+      let(:input) { { foo: 23 } }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with missing input" do
+      let(:input) { {} }
+
+      it "is successful" do
+        expect_successful result
+      end
+    end
+
+    describe "with nil input" do
+      let(:input) { { foo: nil } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be Integer"]
+      end
+    end
+
+    describe "with blank input" do
+      let(:input) { { foo: "" } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be Integer"]
+      end
+    end
+
+    describe "with invalid type" do
+      let(:input) { { foo: [:x] } }
+
+      it "is not successful" do
+        expect_not_successful result, ["must be Integer"]
+      end
+    end
+  end
+
+  describe "as macro" do
+    describe "with required" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              required(:foo).value(type?: Integer)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 23 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be Integer"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be Integer"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be Integer"]
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { foo: [:x] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be Integer"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              required(:foo).filled(type?: Integer)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 23 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be Integer"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be Integer"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be Integer"]
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { foo: [:x] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be Integer"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              required(:foo).maybe(type?: Integer)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 23 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is not successful" do
+            expect_not_successful result, ["is missing", "must be Integer"]
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be Integer"]
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { foo: [:x] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be Integer"]
+          end
+        end
+      end
+    end
+
+    describe "with optional" do
+      describe "with value" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              optional(:foo).value(type?: Integer)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 23 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be Integer"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be Integer"]
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { foo: [:x] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be Integer"]
+          end
+        end
+      end
+
+      describe "with filled" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              optional(:foo).filled(type?: Integer)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 23 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be Integer"]
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be filled", "must be Integer"]
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { foo: [:x] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be Integer"]
+          end
+        end
+      end
+
+      describe "with maybe" do
+        before do
+          @validator = Class.new do
+            include Hanami::Validations
+
+            validations do
+              optional(:foo).maybe(type?: Integer)
+            end
+          end
+        end
+
+        describe "with valid input" do
+          let(:input) { { foo: 23 } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with missing input" do
+          let(:input) { {} }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with nil input" do
+          let(:input) { { foo: nil } }
+
+          it "is successful" do
+            expect_successful result
+          end
+        end
+
+        describe "with blank input" do
+          let(:input) { { foo: "" } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be Integer"]
+          end
+        end
+
+        describe "with invalid type" do
+          let(:input) { { foo: [:x] } }
+
+          it "is not successful" do
+            expect_not_successful result, ["must be Integer"]
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/validations/rules_spec.rb
+++ b/spec/unit/hanami/validations/rules_spec.rb
@@ -2,10 +2,12 @@
 
 require "securerandom"
 
-RSpec.describe Hanami::Validator do
+RSpec.describe Hanami::Validations do
   describe "rules" do
-    subject do
-      Class.new(Hanami::Validator) do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations
+
         validations do
           configure do
             def self.messages
@@ -32,35 +34,37 @@ RSpec.describe Hanami::Validator do
             connection_type.eql?("b") > uuid.filled?
           end
         end
-      end.new
+      end
     end
 
     describe "quick code" do
       it "returns successful validation result for valid data" do
-        result = subject.call(connection_type: "a", quick_code: "123")
+        result = @validator.new(connection_type: "a", quick_code: "123").validate
 
-        expect(result).to be_successful
+        expect(result).to be_success
+        expect(result.errors).to be_empty
       end
 
       it "returns failing validation result when quick code is missing" do
-        result = subject.call(connection_type: "a")
+        result = @validator.new(connection_type: "a").validate
 
-        expect(result).to be_failing
+        expect(result).not_to be_success
         expect(result.messages.fetch(:quick_code_presence)).to eq ['you must set quick code for connection type "a"']
       end
     end
 
     describe "uuid" do
       it "returns successful validation result for valid data" do
-        result = subject.call(connection_type: "b", uuid: SecureRandom.uuid)
+        result = @validator.new(connection_type: "b", uuid: SecureRandom.uuid).validate
 
-        expect(result).to be_successful
+        expect(result).to be_success
+        expect(result.errors).to be_empty
       end
 
       it "returns failing validation result when uuid is missing" do
-        result = subject.call(connection_type: "b")
+        result = @validator.new(connection_type: "b").validate
 
-        expect(result).not_to be_successful
+        expect(result).not_to be_success
         expect(result.messages.fetch(:uuid_presence)).to eq ['you must set uuid for connection type "b"']
       end
     end

--- a/spec/unit/hanami/validations/validates_spec.rb
+++ b/spec/unit/hanami/validations/validates_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+RSpec.describe Hanami::Validations do
+  before do
+    @validator = Class.new do
+      include Hanami::Validations
+
+      validations do
+        required(:name) { filled? }
+      end
+    end
+  end
+
+  it "returns successful validation result for valid data" do
+    result = @validator.new(name: "Luca").validate
+
+    expect(result).to be_success
+    expect(result.errors).to be_empty
+  end
+
+  it "returns failing validation result for invalid data" do
+    result = @validator.new({}).validate
+
+    expect(result).not_to be_success
+    expect(result.messages.fetch(:name)).to eq ["is missing"]
+  end
+end


### PR DESCRIPTION
Reverts hanami/validations#141

After a chat discussion with @timriley and @GustavoCaso we decided to revert these changes, and wait for the `dry-schema` rewriting of `dry-validation`.