### PR TITLE
fix bug that occurred when using i18n and inline predicate at same time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,9 +79,9 @@ jobs:
           name: run tests
           command: |
             ./script/ci
-  "jruby-9.1":
+  "ruby-2.6":
     docker:
-       - image: hanami/jruby-9.1
+       - image: hanami/ruby-2.6
     working_directory: ~/hanami-utils
     steps:
       - checkout
@@ -137,5 +137,5 @@ workflows:
       - "ruby-2.3"
       - "ruby-2.4"
       - "ruby-2.5"
-      - "jruby-9.1"
+      - "ruby-2.6"
       - "jruby-9.2"

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,261 @@
+kind: pipeline
+name: ruby-2-6
+group: build
+
+steps:
+- name: install
+  image: ruby:2.6
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - ruby -v
+  - gem install bundler
+  - bundle install --jobs=3 --retry=3
+
+- name: unit
+  image: ruby:2.6
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - COVERAGE=true bundle exec rake spec:unit
+
+- name: quality
+  image: ruby:2.6
+  environment:
+    CODECOV_TOKEN:
+      from_secret: codecov
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - bundle exec rubocop
+  - CI=true bundle exec rake codecov:upload
+
+volumes:
+- name: bundle
+  temp: {}
+
+---
+kind: pipeline
+name: ruby-2-5
+group: build
+
+steps:
+- name: install
+  image: ruby:2.5
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - ruby -v
+  - gem install bundler
+  - bundle install --jobs=3 --retry=3
+
+- name: unit
+  image: ruby:2.5
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - COVERAGE=true bundle exec rake spec:unit
+
+- name: quality
+  image: ruby:2.5
+  environment:
+    CODECOV_TOKEN:
+      from_secret: codecov
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - bundle exec rubocop
+  - CI=true bundle exec rake codecov:upload
+
+volumes:
+- name: bundle
+  temp: {}
+
+---
+kind: pipeline
+name: ruby-2-4
+group: build
+
+steps:
+- name: install
+  image: ruby:2.4
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - ruby -v
+  - gem install bundler
+  - bundle install --jobs=3 --retry=3
+
+- name: unit
+  image: ruby:2.4
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - COVERAGE=true bundle exec rake spec:unit
+
+- name: quality
+  image: ruby:2.4
+  environment:
+    CODECOV_TOKEN:
+      from_secret: codecov
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - bundle exec rubocop
+  - CI=true bundle exec rake codecov:upload
+
+volumes:
+- name: bundle
+  temp: {}
+
+---
+kind: pipeline
+name: ruby-2-3
+group: build
+
+steps:
+- name: install
+  image: ruby:2.3
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - ruby -v
+  - gem install bundler
+  - bundle install --jobs=3 --retry=3
+
+- name: unit
+  image: ruby:2.3
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - COVERAGE=true bundle exec rake spec:unit
+
+- name: quality
+  image: ruby:2.3
+  environment:
+    CODECOV_TOKEN:
+      from_secret: codecov
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - bundle exec rubocop
+  - CI=true bundle exec rake codecov:upload
+
+volumes:
+- name: bundle
+  temp: {}
+
+---
+kind: pipeline
+name: jruby-9-2
+group: build
+
+steps:
+- name: install
+  image: hanami/jruby-9.2
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - ruby -v
+  - gem install bundler
+  - bundle install --jobs=3 --retry=3
+
+- name: unit
+  image: hanami/jruby-9.2
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - COVERAGE=true bundle exec rake spec:unit
+
+- name: quality
+  image: hanami/jruby-9.2
+  environment:
+    CODECOV_TOKEN:
+      from_secret: codecov
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - bundle exec rubocop
+  - CI=true bundle exec rake codecov:upload
+
+volumes:
+- name: bundle
+  temp: {}
+
+---
+kind: pipeline
+name: jruby-9-1
+group: build
+
+steps:
+- name: install
+  image: hanami/jruby-9.1
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - ruby -v
+  - gem install bundler
+  - bundle install --jobs=3 --retry=3
+
+- name: unit
+  image: hanami/jruby-9.1
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - COVERAGE=true bundle exec rake spec:unit
+
+- name: quality
+  image: hanami/jruby-9.1
+  environment:
+    CODECOV_TOKEN:
+      from_secret: codecov
+  volumes:
+  - name: bundle
+    path: /usr/local/bundle
+  commands:
+  - bundle exec rubocop
+  - CI=true bundle exec rake codecov:upload
+
+volumes:
+- name: bundle
+  temp: {}
+
+---
+kind: pipeline
+name: slack
+group: build
+
+clone:
+  disable: true
+
+depends_on:
+  - jruby-9-1
+
+steps:
+- name: slack
+  image: plugins/slack
+  settings:
+    link_names: true
+    webhook:
+      from_secret: slack
+      channel: dev
+  when:
+    event:
+    - push

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,10 @@ before_script:
   - gem update --system
 script: ./script/ci
 rvm:
-  - 2.4.4
-  - 2.3.7
-  - 2.5.1
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
+  - 2.6.0
   - jruby-9.1.9.0
   - ruby-head
   - jruby-head

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Hanami::Validations
 Validations mixin for Ruby objects
 
+## v1.3.2 - 2019-01-30
+### Fixed
+- [Luca Guidi] Depend on `dry-validation` `~> 0.11.2`, `< 0.12` in order to skip non compatible `dry-logic` `0.5.0`
+
 ## v1.3.1 - 2019-01-18
 ### Added
 - [Luca Guidi] Official support for Ruby: MRI 2.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Hanami::Validations
 Validations mixin for Ruby objects
 
+## v1.3.0 - 2018-10-24
+
 ## v1.3.0.beta1 - 2018-08-08
 ### Added
 - [Luca Guidi] Official support for JRuby 9.2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Hanami::Validations
 Validations mixin for Ruby objects
 
+## v1.3.1 - 2019-01-17
+### Added
+- [Luca Guidi] Official support for Ruby: MRI 2.6
+- [Luca Guidi] Support `bundler` 2.0+
+
 ## v1.3.0 - 2018-10-24
 
 ## v1.3.0.beta1 - 2018-08-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Hanami::Validations
 Validations mixin for Ruby objects
 
-## v1.3.1 - 2019-01-17
+## v1.3.1 - 2019-01-18
 ### Added
 - [Luca Guidi] Official support for Ruby: MRI 2.6
 - [Luca Guidi] Support `bundler` 2.0+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Hanami::Validations
 Validations mixin for Ruby objects
 
+## v1.3.0.beta1 - 2018-08-08
+### Added
+- [Luca Guidi] Official support for JRuby 9.2.0.0
+
 ## v1.2.2 - 2018-06-05
 ### Fixed
 - [Luca Guidi] Revert dependency to `dry-validation` to `~> 0.11`, `< 0.12`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Hanami::Validations
 Validations mixin for Ruby objects
 
+## v1.3.3 - 2019-01-31
+### Fixed
+- [Luca Guidi] Depend on `dry-validation` `~> 0.11`, `< 0.12`
+- [Luca Guidi] Depend on `dry-logic` `~> 0.4.2`, `< 0.5`
+
 ## v1.3.2 - 2019-01-30
 ### Fixed
 - [Luca Guidi] Depend on `dry-validation` `~> 0.11.2`, `< 0.12` in order to skip non compatible `dry-logic` `0.5.0`

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ unless ENV['CI']
   gem 'yard',   require: false
 end
 
-gem 'hanami-utils', '~> 1.3.beta', require: false, git: 'https://github.com/hanami/utils.git', branch: 'develop'
+gem 'hanami-utils', '~> 1.3', require: false, git: 'https://github.com/hanami/utils.git', branch: 'master'
 
 gem 'hanami-devtools', require: false, git: 'https://github.com/hanami/devtools.git'
 gem 'i18n', '~> 1.0',  require: false

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ unless ENV['CI']
   gem 'yard',   require: false
 end
 
-gem 'hanami-utils', '~> 1.2', require: false, git: 'https://github.com/hanami/utils.git', branch: 'master'
+gem 'hanami-utils', '~> 1.3.beta', require: false, git: 'https://github.com/hanami/utils.git', branch: 'develop'
 
 gem 'hanami-devtools', require: false, git: 'https://github.com/hanami/devtools.git'
 gem 'i18n', '~> 1.0',  require: false

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Validations mixin for Ruby objects
 ## Contact
 
 * Home page: http://hanamirb.org
+* Community: http://hanamirb.org/community
+* Guides: https://guides.hanamirb.org
 * Mailing List: http://hanamirb.org/mailing-list
 * API Doc: http://rdoc.info/gems/hanami-validations
 * Bugs/Issues: https://github.com/hanami/validations/issues

--- a/hanami-validations.gemspec
+++ b/hanami-validations.gemspec
@@ -19,7 +19,8 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3.0'
 
   spec.add_dependency 'hanami-utils',   '~> 1.3'
-  spec.add_dependency 'dry-validation', '~> 0.11.2', '< 0.12'
+  spec.add_dependency 'dry-validation', '~> 0.11', '< 0.12'
+  spec.add_dependency 'dry-logic',      '~> 0.4.2', '< 0.5'
 
   spec.add_development_dependency 'bundler', '>= 1.6', '< 3'
   spec.add_development_dependency 'rake',    '~> 12'

--- a/hanami-validations.gemspec
+++ b/hanami-validations.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3.0'
 
   spec.add_dependency 'hanami-utils',   '~> 1.3'
-  spec.add_dependency 'dry-validation', '~> 0.11', '< 0.12'
+  spec.add_dependency 'dry-validation', '~> 0.11.2', '< 0.12'
 
   spec.add_development_dependency 'bundler', '>= 1.6', '< 3'
   spec.add_development_dependency 'rake',    '~> 12'

--- a/hanami-validations.gemspec
+++ b/hanami-validations.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.3.0'
 
-  spec.add_dependency 'hanami-utils',   '~> 1.3.beta'
+  spec.add_dependency 'hanami-utils',   '~> 1.3'
   spec.add_dependency 'dry-validation', '~> 0.11', '< 0.12'
 
   spec.add_development_dependency 'bundler', '~> 1.6'

--- a/hanami-validations.gemspec
+++ b/hanami-validations.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'hanami-utils',   '~> 1.3'
   spec.add_dependency 'dry-validation', '~> 0.11', '< 0.12'
 
-  spec.add_development_dependency 'bundler', '~> 1.6'
+  spec.add_development_dependency 'bundler', '> 1', '< 3'
   spec.add_development_dependency 'rake',    '~> 12'
   spec.add_development_dependency 'rspec',   '~> 3.7'
 end

--- a/hanami-validations.gemspec
+++ b/hanami-validations.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.3.0'
 
-  spec.add_dependency 'hanami-utils',   '~> 1.2'
+  spec.add_dependency 'hanami-utils',   '~> 1.3.beta'
   spec.add_dependency 'dry-validation', '~> 0.11', '< 0.12'
 
   spec.add_development_dependency 'bundler', '~> 1.6'

--- a/hanami-validations.gemspec
+++ b/hanami-validations.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'hanami-utils',   '~> 1.3'
   spec.add_dependency 'dry-validation', '~> 0.11', '< 0.12'
 
-  spec.add_development_dependency 'bundler', '> 1', '< 3'
+  spec.add_development_dependency 'bundler', '>= 1.6', '< 3'
   spec.add_development_dependency 'rake',    '~> 12'
   spec.add_development_dependency 'rspec',   '~> 3.7'
 end

--- a/lib/hanami/validations.rb
+++ b/lib/hanami/validations.rb
@@ -337,8 +337,6 @@ module Hanami
           def messages
             engine = super
 
-            return engine.messages if @_config.messages == :i18n
-
             if engine.respond_to?(:merge)
               engine
             else

--- a/lib/hanami/validations.rb
+++ b/lib/hanami/validations.rb
@@ -294,7 +294,7 @@ module Hanami
         return if _predicates_module.nil? && _predicates.empty?
 
         lambda do |config|
-          config.messages      = _predicates_module&.messages || DEFAULT_MESSAGES_ENGINE
+          config.messages      = _predicates_module&.messages || @_messages || DEFAULT_MESSAGES_ENGINE
           config.messages_file = _predicates_module.messages_path unless _predicates_module.nil?
         end
       end
@@ -336,6 +336,8 @@ module Hanami
           # @api private
           def messages
             engine = super
+
+            return engine.messages if @_config.messages == :i18n
 
             if engine.respond_to?(:merge)
               engine

--- a/lib/hanami/validations.rb
+++ b/lib/hanami/validations.rb
@@ -337,13 +337,13 @@ module Hanami
           def messages
             engine = super
 
-            return engine.messages if @_config.messages == :i18n
+            messages = if engine.respond_to?(:merge)
+                         engine
+                       else
+                         engine.messages
+                       end
 
-            if engine.respond_to?(:merge)
-              engine
-            else
-              engine.messages
-            end.merge(__messages)
+            config.messages == :i18n ? messages : messages.merge(__messages)
           end
         end
       end

--- a/lib/hanami/validations.rb
+++ b/lib/hanami/validations.rb
@@ -290,7 +290,7 @@ module Hanami
 
       # @since 0.6.0
       # @api private
-      def _schema_predicates
+      def _schema_predicates # rubocop:disabled Metrics/CyclomaticComplexity
         return if _predicates_module.nil? && _predicates.empty?
 
         lambda do |config|

--- a/lib/hanami/validations.rb
+++ b/lib/hanami/validations.rb
@@ -290,7 +290,7 @@ module Hanami
 
       # @since 0.6.0
       # @api private
-      def _schema_predicates # rubocop:disabled Metrics/CyclomaticComplexity
+      def _schema_predicates # rubocop:disable Metrics/CyclomaticComplexity
         return if _predicates_module.nil? && _predicates.empty?
 
         lambda do |config|

--- a/lib/hanami/validations.rb
+++ b/lib/hanami/validations.rb
@@ -71,7 +71,7 @@ module Hanami
       #
       # @since 0.6.0
       #
-      # @see http://hanamirb.org/guides/validations/overview/
+      # @see https://guides.hanamirb.org/validations/overview
       #
       # @example Basic Example
       #   require 'hanami/validations'

--- a/lib/hanami/validations.rb
+++ b/lib/hanami/validations.rb
@@ -337,6 +337,8 @@ module Hanami
           def messages
             engine = super
 
+            return engine.messages if @_config.messages == :i18n
+
             if engine.respond_to?(:merge)
               engine
             else

--- a/lib/hanami/validations/version.rb
+++ b/lib/hanami/validations/version.rb
@@ -1,6 +1,6 @@
 module Hanami
   module Validations
     # @since 0.1.0
-    VERSION = '1.3.0'.freeze
+    VERSION = '1.3.1'.freeze
   end
 end

--- a/lib/hanami/validations/version.rb
+++ b/lib/hanami/validations/version.rb
@@ -1,6 +1,6 @@
 module Hanami
   module Validations
     # @since 0.1.0
-    VERSION = '1.3.2'.freeze
+    VERSION = '1.3.3'.freeze
   end
 end

--- a/lib/hanami/validations/version.rb
+++ b/lib/hanami/validations/version.rb
@@ -1,6 +1,6 @@
 module Hanami
   module Validations
     # @since 0.1.0
-    VERSION = '1.2.2'.freeze
+    VERSION = '1.3.0.beta1'.freeze
   end
 end

--- a/lib/hanami/validations/version.rb
+++ b/lib/hanami/validations/version.rb
@@ -1,6 +1,6 @@
 module Hanami
   module Validations
     # @since 0.1.0
-    VERSION = '1.3.0.beta1'.freeze
+    VERSION = '1.3.0'.freeze
   end
 end

--- a/lib/hanami/validations/version.rb
+++ b/lib/hanami/validations/version.rb
@@ -1,6 +1,6 @@
 module Hanami
   module Validations
     # @since 0.1.0
-    VERSION = '1.3.1'.freeze
+    VERSION = '1.3.2'.freeze
   end
 end

--- a/spec/support/fixtures/i18n/en.yml
+++ b/spec/support/fixtures/i18n/en.yml
@@ -1,6 +1,7 @@
 en:
   errors:
     accepted?: "must be accepted"
+    url?: "must be an URL"
     rules:
       domain:
         name:

--- a/spec/unit/hanami/validations/form/initialize_spec.rb
+++ b/spec/unit/hanami/validations/form/initialize_spec.rb
@@ -60,8 +60,8 @@ RSpec.describe Hanami::Validations::Form do
 
     it 'accepts strings as keys, only for the defined attributes' do
       validator = @nested.new(
-        'foo'     => 'ok',
-        'num'     => '23',
+        'foo' => 'ok',
+        'num' => '23',
         'unknown' => 'no',
         'bar' => {
           'baz' => 'yo',

--- a/spec/unit/hanami/validations/form/rules_spec.rb
+++ b/spec/unit/hanami/validations/form/rules_spec.rb
@@ -28,10 +28,10 @@ RSpec.describe Hanami::Validations::Form do
 
     let(:input) do
       Hash[
-        'type'        => '1',
-        'title'       => 'Developer',
+        'type' => '1',
+        'title' => 'Developer',
         'description' => 'You know, to write code.',
-        'company'     => 'Acme Inc.'
+        'company' => 'Acme Inc.'
       ]
     end
 

--- a/spec/unit/hanami/validations/initialize_spec.rb
+++ b/spec/unit/hanami/validations/initialize_spec.rb
@@ -65,8 +65,8 @@ RSpec.describe Hanami::Validations do
 
     it 'accepts symbols as keys, without coercing and whitelisting' do
       validator = @nested.new(
-        foo:     'ok',
-        num:     23,
+        foo: 'ok',
+        num: 23,
         unknown: 'no',
         bar: {
           baz: 'yo',
@@ -78,8 +78,8 @@ RSpec.describe Hanami::Validations do
 
       expect(result).to be_success
       expect(result.output).to eq(
-        foo:     'ok',
-        num:     23,
+        foo: 'ok',
+        num: 23,
         unknown: 'no',
         bar: {
           baz: 'yo',

--- a/spec/unit/hanami/validations/predicates/form/custom_spec.rb
+++ b/spec/unit/hanami/validations/predicates/form/custom_spec.rb
@@ -120,6 +120,44 @@ RSpec.describe 'Predicates: custom' do
     end
   end
 
+  describe 'with i18n' do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations::Form
+
+        def self.name
+          'Validator'
+        end
+
+        messages :i18n
+
+        predicate :url? do |current|
+          current.start_with?('http')
+        end
+
+        validations do
+          required(:foo) { url? }
+        end
+      end
+    end
+
+    describe 'with valid input' do
+      let(:input) { { foo: 'http://hanamirb.org' } }
+
+      it 'is successful' do
+        expect_successful result
+      end
+    end
+
+    describe 'with invalid input' do
+      let(:input) { { foo: 'test' } }
+
+      it 'is successful' do
+        expect_not_successful result, ['must be an URL']
+      end
+    end
+  end
+
   describe 'with custom predicate with predicate macro' do
     before do
       @validator = Class.new do

--- a/spec/unit/hanami/validations/predicates/schema/custom_spec.rb
+++ b/spec/unit/hanami/validations/predicates/schema/custom_spec.rb
@@ -120,6 +120,44 @@ RSpec.describe 'Predicates: custom' do
     end
   end
 
+  describe 'with i18n' do
+    before do
+      @validator = Class.new do
+        include Hanami::Validations
+
+        def self.name
+          'Validator'
+        end
+
+        messages :i18n
+
+        predicate :url? do |current|
+          current.start_with?('http')
+        end
+
+        validations do
+          required(:foo) { url? }
+        end
+      end
+    end
+
+    describe 'with valid input' do
+      let(:input) { { foo: 'http://hanamirb.org' } }
+
+      it 'is successful' do
+        expect_successful result
+      end
+    end
+
+    describe 'with invalid input' do
+      let(:input) { { foo: 'test' } }
+
+      it 'is successful' do
+        expect_not_successful result, ['must be an URL']
+      end
+    end
+  end
+
   describe 'without custom predicate' do
     it 'raises error if try to use an unknown predicate' do
       expect do

--- a/spec/unit/hanami/validations/rules_spec.rb
+++ b/spec/unit/hanami/validations/rules_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Hanami::Validations do
                 en: {
                   errors: {
                     quick_code_presence: 'you must set quick code for connection type "a"',
-                    uuid_presence:       'you must set uuid for connection type "b"'
+                    uuid_presence: 'you must set uuid for connection type "b"'
                   }
                 }
               )

--- a/spec/unit/hanami/validations/version_spec.rb
+++ b/spec/unit/hanami/validations/version_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "Hanami::Validations::VERSION" do
   it "exposes version" do
-    expect(Hanami::Validations::VERSION).to eq("1.3.0")
+    expect(Hanami::Validations::VERSION).to eq("1.3.1")
   end
 end

--- a/spec/unit/hanami/validations/version_spec.rb
+++ b/spec/unit/hanami/validations/version_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "Hanami::Validations::VERSION" do
   it "exposes version" do
-    expect(Hanami::Validations::VERSION).to eq("1.2.2")
+    expect(Hanami::Validations::VERSION).to eq("1.3.0.beta1")
   end
 end

--- a/spec/unit/hanami/validations/version_spec.rb
+++ b/spec/unit/hanami/validations/version_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "Hanami::Validations::VERSION" do
   it "exposes version" do
-    expect(Hanami::Validations::VERSION).to eq("1.3.0.beta1")
+    expect(Hanami::Validations::VERSION).to eq("1.3.0")
   end
 end

--- a/spec/unit/hanami/validations/version_spec.rb
+++ b/spec/unit/hanami/validations/version_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "Hanami::Validations::VERSION" do
   it "exposes version" do
-    expect(Hanami::Validations::VERSION).to eq("1.3.1")
+    expect(Hanami::Validations::VERSION).to eq("1.3.2")
   end
 end

--- a/spec/unit/hanami/validations/version_spec.rb
+++ b/spec/unit/hanami/validations/version_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "Hanami::Validations::VERSION" do
   it "exposes version" do
-    expect(Hanami::Validations::VERSION).to eq("1.3.2")
+    expect(Hanami::Validations::VERSION).to eq("1.3.3")
   end
 end


### PR DESCRIPTION
Closes #152 

- Inline predicate with block overridden `messages` to `:yaml`. 
So if `messages` is set on validator class, fixed to take over that value.

- `engine.messages` return `#<Dry::Validation::Messages::I18n` or `#<Dry::Validation::Messages::YAML `.
`#<Dry::Validation::Messages::YAML#merge` expect filepath or hash. 
`#<Dry::Validation::Messages::I18n#merge` expect only filepath.
So if `messages` is set `:i18n`, fixed to return `engine.messages` without merge error message hash.