### PR TITLE
Depend on `dry-validation` `~> 0.11.2`, `< 0.12`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Hanami::Validations
 Validations mixin for Ruby objects
 
+## v1.3.2 - 2019-01-30
+### Fixed
+- [Luca Guidi] Depend on `dry-validation` `~> 0.11.2`, `< 0.12` in order to skip non compatible `dry-logic` `0.5.0`
+
 ## v1.3.1 - 2019-01-18
 ### Added
 - [Luca Guidi] Official support for Ruby: MRI 2.6

--- a/hanami-validations.gemspec
+++ b/hanami-validations.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3.0'
 
   spec.add_dependency 'hanami-utils',   '~> 1.3'
-  spec.add_dependency 'dry-validation', '~> 0.11', '< 0.12'
+  spec.add_dependency 'dry-validation', '~> 0.11.2', '< 0.12'
 
   spec.add_development_dependency 'bundler', '>= 1.6', '< 3'
   spec.add_development_dependency 'rake',    '~> 12'

--- a/lib/hanami/validations/version.rb
+++ b/lib/hanami/validations/version.rb
@@ -1,6 +1,6 @@
 module Hanami
   module Validations
     # @since 0.1.0
-    VERSION = '1.3.1'.freeze
+    VERSION = '1.3.2'.freeze
   end
 end

--- a/spec/unit/hanami/validations/version_spec.rb
+++ b/spec/unit/hanami/validations/version_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "Hanami::Validations::VERSION" do
   it "exposes version" do
-    expect(Hanami::Validations::VERSION).to eq("1.3.1")
+    expect(Hanami::Validations::VERSION).to eq("1.3.2")
   end
 end


### PR DESCRIPTION
## Manual testing

  1. `gem install hanami`
  1. `hanami new bookshelf` will crash
  1. Pull this branch locally
  1. Locally install `hanami-validations` `1.3.2` with `bundle exec rake install`
  1. `hanami new bookshelf` will succeed

---

Ref https://github.com/hanami/hanami/issues/987