### PR TITLE
Upgrade to dry-validation 0.13

### DIFF
--- a/hanami-validations.gemspec
+++ b/hanami-validations.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3.0'
 
   spec.add_dependency 'hanami-utils',   '~> 1.3'
-  spec.add_dependency 'dry-validation', '~> 0.11', '< 0.12'
-  spec.add_dependency 'dry-logic',      '~> 0.4.2', '< 0.5'
+  spec.add_dependency 'dry-validation', '~> 0.13', '< 1.0.0'
+  spec.add_dependency 'dry-logic',      '~> 0.5.0', '< 1.0.0'
 
   spec.add_development_dependency 'bundler', '>= 1.6', '< 3'
   spec.add_development_dependency 'rake',    '~> 12'

--- a/lib/hanami/validations.rb
+++ b/lib/hanami/validations.rb
@@ -6,14 +6,12 @@ require 'hanami/validations/inline_predicate'
 require 'set'
 
 Dry::Validation::Messages::Namespaced.configure do |config|
-  # rubocop:disable Lint/NestedPercentLiteral
   #
   # This is probably a false positive.
   # See: https://github.com/bbatsov/rubocop/issues/5314
   config.lookup_paths = config.lookup_paths + %w[
     %<root>s.%<rule>s.%<predicate>s
   ].freeze
-  # rubocop:enable Lint/NestedPercentLiteral
 end
 
 # @since 0.1.0
@@ -45,7 +43,7 @@ module Hanami
     # @api private
     #
     # @see http://www.ruby-doc.org/core/Module.html#method-i-included
-    def self.included(base) # rubocop:disable Metrics/MethodLength
+    def self.included(base)
       base.class_eval do
         extend ClassMethods
 
@@ -95,7 +93,7 @@ module Hanami
       #   result.success? # => false
       #   result.messages # => {:name=>["must be filled"]}
       #   result.output   # => {:name=>""}
-      def validations(&blk) # rubocop:disable Metrics/AbcSize
+      def validations(&blk)
         schema_predicates = _predicates_module || __predicates
 
         base   = _build(predicates: schema_predicates, &_base_rules)
@@ -291,11 +289,14 @@ module Hanami
       # @since 0.6.0
       # @api private
       def _schema_predicates
-        return if _predicates_module.nil? && _predicates.empty?
+        # rubocop:disable Style/NilComparison
+        return if _predicates_module == nil && _predicates.empty?
+
+        # rubocop:enable Style/NilComparison
 
         lambda do |config|
           config.messages      = _predicates_module&.messages || DEFAULT_MESSAGES_ENGINE
-          config.messages_file = _predicates_module.messages_path unless _predicates_module.nil?
+          config.messages_file = _predicates_module.messages_path if _predicates_module
         end
       end
 
@@ -315,14 +316,14 @@ module Hanami
 
       # @since 0.6.0
       # @api private
-      def __messages # rubocop:disable Metrics/MethodLength
+      def __messages
         result = _predicates.each_with_object({}) do |p, ret|
           ret[p.name] = p.message
         end
 
         # @api private
         Module.new do
-          @@__messages = result # rubocop:disable Style/ClassVars
+          @@__messages = result
 
           # @api private
           def self.extended(base)

--- a/lib/hanami/validations/form.rb
+++ b/lib/hanami/validations/form.rb
@@ -60,7 +60,7 @@ module Hanami
         # @since 0.6.0
         # @api private
         def _schema_type
-          :Form
+          :Params
         end
       end
     end


### PR DESCRIPTION
This PR bumps the dependency on dry-validation to 0.13. A few gems in the Hanami ecosystem rely on this, and we were locked with 0.11, and oldcer versions of other dry gems. Hopefully this sets us up for an easier migration since dry-validation 1.0 coming out soon.