### PR TITLE
Pin `dry-configurable` at `<= 0.12`

### DIFF
--- a/hanami-validations.gemspec
+++ b/hanami-validations.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "hanami-utils",     "~> 1.3"
   spec.add_dependency "dry-validation",   "~> 0.11", "< 0.12"
   spec.add_dependency "dry-logic",        "~> 0.4.2", "< 0.5"
-  spec.add_dependency "dry-configurable", "0.12.1"
+  spec.add_dependency "dry-configurable", "<= 0.12"
 
   spec.add_development_dependency "bundler", ">= 1.6", "< 3"
   spec.add_development_dependency "rake",    "~> 13"


### PR DESCRIPTION
Due to breaking changes in `dry-configurable` `0.13.x`, we need to pin at `<= 0.12`.
`dry-configurable` is a transitive dependency of `dry-validation`, which is a direct runtime dependency for `hanami-validations`.

Without this fix, CI won't start.

---

Ref https://github.com/hanami/hanami/issues/1126