### PR TITLE
[v1.3] Pin `dry-container` at `<= 0.9`

### DIFF
--- a/hanami-validations.gemspec
+++ b/hanami-validations.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dry-validation",   "~> 0.11", "< 0.12"
   spec.add_dependency "dry-logic",        "~> 0.4.2", "< 0.5"
   spec.add_dependency "dry-configurable", "<= 0.12"
+  spec.add_dependency "dry-container", "<= 0.9"
 
   spec.add_development_dependency "bundler", ">= 1.6", "< 3"
   spec.add_development_dependency "rake",    "~> 13"


### PR DESCRIPTION
Similar to #221. The issue is that `dry-types` expects `dry-configurable` to be required, since it used to be required by `dry-container` but with 0.10, it no longer is.


This issue is causing `hanami new` to fail: https://github.com/hanami/hanami/issues/1182